### PR TITLE
Add API-backed blog management

### DIFF
--- a/api/blogs.js
+++ b/api/blogs.js
@@ -1,0 +1,450 @@
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+const DATA_DIR = path.join(process.cwd(), 'data');
+const DB_PATH = path.join(DATA_DIR, 'blogs.sqlite');
+
+let initPromise = null;
+
+function buildParameterCommands(params) {
+  const commands = [];
+  const entries = Object.entries(params || {});
+  if (!entries.length) return commands;
+
+  commands.push('.parameter init');
+  for (const [key, value] of entries) {
+    if (value === undefined) continue;
+    let command;
+    if (value === null) {
+      command = `.parameter set @${key} NULL`;
+    } else if (typeof value === 'number' || typeof value === 'bigint') {
+      command = `.parameter set @${key} ${Number(value)}`;
+    } else if (typeof value === 'boolean') {
+      command = `.parameter set @${key} ${value ? 1 : 0}`;
+    } else {
+      const safe = String(value).replace(/'/g, "''");
+      command = `.parameter set @${key} '${safe}'`;
+    }
+    commands.push(command);
+  }
+  return commands;
+}
+
+function runSql(sql, params = {}, { json = false } = {}) {
+  return new Promise((resolve, reject) => {
+    const statements = Array.isArray(sql) ? sql.join('\n') : String(sql || '');
+    const args = [];
+
+    if (json) {
+      args.push('-json');
+    }
+
+    args.push(DB_PATH);
+
+    const paramCommands = buildParameterCommands(params);
+    for (const cmd of paramCommands) {
+      args.push('-cmd', cmd);
+    }
+
+    args.push(statements);
+
+    const child = spawn('sqlite3', args);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data;
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data;
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        const error = new Error(stderr || `sqlite3 exited with code ${code}`);
+        error.stderr = stderr;
+        error.code = code;
+        return reject(error);
+      }
+
+      if (!json) {
+        return resolve(stdout);
+      }
+
+      const trimmed = stdout.trim();
+      if (!trimmed) {
+        return resolve([]);
+      }
+
+      try {
+        resolve(JSON.parse(trimmed));
+      } catch (parseError) {
+        parseError.stdout = stdout;
+        parseError.stderr = stderr;
+        reject(parseError);
+      }
+    });
+  });
+}
+
+async function ensureDatabase() {
+  if (!initPromise) {
+    initPromise = (async () => {
+      await fs.promises.mkdir(DATA_DIR, { recursive: true });
+      await runSql(
+        `PRAGMA journal_mode=WAL;\n` +
+          `CREATE TABLE IF NOT EXISTS blog_posts (\n` +
+          `  id INTEGER PRIMARY KEY AUTOINCREMENT,\n` +
+          `  title TEXT NOT NULL,\n` +
+          `  slug TEXT NOT NULL UNIQUE,\n` +
+          `  meta_title TEXT,\n` +
+          `  meta_description TEXT,\n` +
+          `  content TEXT NOT NULL,\n` +
+          `  featured_image TEXT,\n` +
+          `  status TEXT DEFAULT 'draft',\n` +
+          `  publish_date TEXT,\n` +
+          `  published_date TEXT,\n` +
+          `  read_time INTEGER,\n` +
+          `  created_at TEXT NOT NULL,\n` +
+          `  updated_at TEXT NOT NULL\n` +
+          `);\n` +
+          `CREATE INDEX IF NOT EXISTS idx_blog_posts_slug ON blog_posts(slug);`
+      );
+    })();
+  }
+  return initPromise;
+}
+
+function toCamelCase(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    metaTitle: row.meta_title || '',
+    metaDescription: row.meta_description || '',
+    content: row.content || '',
+    featuredImage: row.featured_image || null,
+    status: row.status || 'draft',
+    publishDate: row.publish_date || null,
+    publishedDate: row.published_date || null,
+    readTime: row.read_time !== null && row.read_time !== undefined ? Number(row.read_time) : null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function parseBody(req) {
+  if (!req.body) return {};
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body || '{}');
+    } catch (error) {
+      return {};
+    }
+  }
+  return req.body || {};
+}
+
+function isValidStatus(status) {
+  return ['draft', 'scheduled', 'published', 'offline'].includes(status);
+}
+
+async function handleGet(req, res) {
+  const { id, slug, status } = req.query || {};
+  const params = {};
+  let sql =
+    'SELECT id, title, slug, meta_title, meta_description, content, featured_image, status, publish_date, published_date, read_time, created_at, updated_at FROM blog_posts';
+
+  const conditions = [];
+  if (id) {
+    conditions.push('id = @id');
+    params.id = Number(id);
+  }
+  if (slug) {
+    conditions.push('slug = @slug');
+    params.slug = slug;
+  }
+  if (status) {
+    conditions.push('status = @status');
+    params.status = status;
+  }
+
+  if (conditions.length) {
+    sql += ' WHERE ' + conditions.join(' AND ');
+  }
+
+  if (id || slug) {
+    sql += ' LIMIT 1';
+  } else {
+    sql += ' ORDER BY datetime(updated_at) DESC, datetime(created_at) DESC';
+  }
+
+  sql += ';';
+
+  const rows = await runSql(sql, params, { json: true });
+  if (id || slug) {
+    const row = rows[0];
+    if (!row) {
+      res.status(404).json({ error: 'Blogpost niet gevonden' });
+      return;
+    }
+    res.status(200).json({ success: true, data: toCamelCase(row) });
+    return;
+  }
+
+  res.status(200).json({ success: true, data: rows.map(toCamelCase) });
+}
+
+async function handlePost(req, res) {
+  const body = parseBody(req);
+  const title = (body.title || '').trim();
+  const slug = (body.slug || '').trim();
+  const content = body.content || '';
+  const status = body.status && isValidStatus(body.status) ? body.status : 'draft';
+
+  if (!title) {
+    res.status(400).json({ error: 'Titel is verplicht' });
+    return;
+  }
+  if (!slug) {
+    res.status(400).json({ error: 'Slug is verplicht' });
+    return;
+  }
+  if (!content) {
+    res.status(400).json({ error: 'Inhoud is verplicht' });
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const params = {
+    title,
+    slug,
+    metaTitle: body.metaTitle || '',
+    metaDescription: body.metaDescription || '',
+    content,
+    featuredImage: body.featuredImage || null,
+    status,
+    publishDate: body.publishDate || null,
+    publishedDate: body.publishedDate || null,
+    readTime:
+      typeof body.readTime === 'number' && !Number.isNaN(body.readTime)
+        ? Math.max(0, Math.round(body.readTime))
+        : null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  try {
+    const insertResult = await runSql(
+      `INSERT INTO blog_posts (\n` +
+        `  title, slug, meta_title, meta_description, content, featured_image, status, publish_date, published_date, read_time, created_at, updated_at\n` +
+        `) VALUES (\n` +
+        `  @title, @slug, @metaTitle, @metaDescription, @content, @featuredImage, @status, @publishDate, @publishedDate, @readTime, @createdAt, @updatedAt\n` +
+        `);\n` +
+        `SELECT last_insert_rowid() AS id;`,
+      params,
+      { json: true }
+    );
+
+    const newId = insertResult?.[0]?.id;
+    if (!newId) {
+      res.status(500).json({ error: 'Kon ID van nieuwe blogpost niet ophalen' });
+      return;
+    }
+
+    const created = await runSql(
+      'SELECT id, title, slug, meta_title, meta_description, content, featured_image, status, publish_date, published_date, read_time, created_at, updated_at FROM blog_posts WHERE id = @id;',
+      { id: newId },
+      { json: true }
+    );
+
+    res.status(201).json({ success: true, data: toCamelCase(created[0]) });
+  } catch (error) {
+    const message = String(error.stderr || error.message || '').toLowerCase();
+    if (message.includes('unique constraint failed')) {
+      res.status(409).json({ error: 'Slug is al in gebruik' });
+      return;
+    }
+    console.error('Blog POST error:', error);
+    res.status(500).json({ error: 'Kon blogpost niet opslaan' });
+  }
+}
+
+async function handlePut(req, res) {
+  const queryId = req.query?.id;
+  const body = parseBody(req);
+  const bodyId = body && body.id ? body.id : null;
+  const targetId = queryId || bodyId;
+
+  if (!targetId) {
+    res.status(400).json({ error: 'ID is verplicht voor updates' });
+    return;
+  }
+
+  const updates = [];
+  const params = { id: Number(targetId) };
+
+  if ('title' in body) {
+    params.title = (body.title || '').trim();
+    if (!params.title) {
+      res.status(400).json({ error: 'Titel is verplicht' });
+      return;
+    }
+    updates.push('title = @title');
+  }
+  if ('slug' in body) {
+    params.slug = (body.slug || '').trim();
+    if (!params.slug) {
+      res.status(400).json({ error: 'Slug is verplicht' });
+      return;
+    }
+    updates.push('slug = @slug');
+  }
+  if ('metaTitle' in body) {
+    params.metaTitle = body.metaTitle || '';
+    updates.push('meta_title = @metaTitle');
+  }
+  if ('metaDescription' in body) {
+    params.metaDescription = body.metaDescription || '';
+    updates.push('meta_description = @metaDescription');
+  }
+  if ('content' in body) {
+    params.content = body.content || '';
+    if (!params.content) {
+      res.status(400).json({ error: 'Inhoud is verplicht' });
+      return;
+    }
+    updates.push('content = @content');
+  }
+  if ('featuredImage' in body) {
+    params.featuredImage = body.featuredImage || null;
+    updates.push('featured_image = @featuredImage');
+  }
+  if ('status' in body) {
+    const status = body.status;
+    if (!isValidStatus(status)) {
+      res.status(400).json({ error: 'Ongeldige status' });
+      return;
+    }
+    params.status = status;
+    updates.push('status = @status');
+  }
+  if ('publishDate' in body) {
+    params.publishDate = body.publishDate || null;
+    updates.push('publish_date = @publishDate');
+  }
+  if ('publishedDate' in body) {
+    params.publishedDate = body.publishedDate || null;
+    updates.push('published_date = @publishedDate');
+  }
+  if ('readTime' in body) {
+    if (body.readTime === null || body.readTime === undefined || body.readTime === '') {
+      params.readTime = null;
+    } else {
+      const readTime = Number(body.readTime);
+      params.readTime = Number.isNaN(readTime) ? null : Math.max(0, Math.round(readTime));
+    }
+    updates.push('read_time = @readTime');
+  }
+
+  if (!updates.length) {
+    res.status(400).json({ error: 'Geen velden om bij te werken' });
+    return;
+  }
+
+  params.updatedAt = new Date().toISOString();
+  updates.push('updated_at = @updatedAt');
+
+  try {
+    const result = await runSql(
+      `UPDATE blog_posts SET ${updates.join(', ')} WHERE id = @id;\nSELECT changes() AS changes;`,
+      params,
+      { json: true }
+    );
+
+    const changes = result?.[0]?.changes || 0;
+    if (!changes) {
+      res.status(404).json({ error: 'Blogpost niet gevonden' });
+      return;
+    }
+
+    const updated = await runSql(
+      'SELECT id, title, slug, meta_title, meta_description, content, featured_image, status, publish_date, published_date, read_time, created_at, updated_at FROM blog_posts WHERE id = @id;',
+      { id: params.id },
+      { json: true }
+    );
+
+    res.status(200).json({ success: true, data: toCamelCase(updated[0]) });
+  } catch (error) {
+    const message = String(error.stderr || error.message || '').toLowerCase();
+    if (message.includes('unique constraint failed')) {
+      res.status(409).json({ error: 'Slug is al in gebruik' });
+      return;
+    }
+    console.error('Blog PUT error:', error);
+    res.status(500).json({ error: 'Kon blogpost niet bijwerken' });
+  }
+}
+
+async function handleDelete(req, res) {
+  const { id } = req.query || {};
+  if (!id) {
+    res.status(400).json({ error: 'ID is verplicht om te verwijderen' });
+    return;
+  }
+
+  const result = await runSql(
+    'DELETE FROM blog_posts WHERE id = @id;\nSELECT changes() AS changes;',
+    { id: Number(id) },
+    { json: true }
+  );
+
+  const changes = result?.[0]?.changes || 0;
+  if (!changes) {
+    res.status(404).json({ error: 'Blogpost niet gevonden' });
+    return;
+  }
+
+  res.status(200).json({ success: true });
+}
+
+export default async function handler(req, res) {
+  try {
+    await ensureDatabase();
+
+    if (req.method === 'GET') {
+      await handleGet(req, res);
+      return;
+    }
+
+    if (req.method === 'POST') {
+      await handlePost(req, res);
+      return;
+    }
+
+    if (req.method === 'PUT' || req.method === 'PATCH') {
+      await handlePut(req, res);
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      await handleDelete(req, res);
+      return;
+    }
+
+    res.setHeader('Allow', 'GET,POST,PUT,PATCH,DELETE');
+    res.status(405).json({ error: 'Methode niet toegestaan' });
+  } catch (error) {
+    console.error('Blog API fout:', error);
+    res.status(500).json({ error: 'Onverwachte serverfout' });
+  }
+}
+

--- a/blog-editor.html
+++ b/blog-editor.html
@@ -433,12 +433,17 @@
   </div>
 
   <script>
-    (function(){
-      // Check if user has access
-      const key='staff_access_ok';
-      if(localStorage.getItem(key)!=='1'){ 
-        window.location.href='/personeel'; 
-        return; 
+    (async function(){
+      // Check if user has access via cookie set op het personeelsscherm
+      function hasStaffAccess(){
+        return document.cookie.split(';').some(function(part){
+          return part.trim().startsWith('staff_access_ok=');
+        });
+      }
+
+      if(!hasStaffAccess()){
+        window.location.href='/personeel';
+        return;
       }
       
       // Get elements
@@ -461,7 +466,86 @@
       
       // Check if we're editing an existing post
       const urlParams = new URLSearchParams(window.location.search);
-      const editId = urlParams.get('edit');
+      let editId = urlParams.get('edit');
+      let currentPost = null;
+      let blogPostsCache = [];
+      const API_BASE = '/api/blogs';
+
+      async function fetchJson(url, options = {}) {
+        const init = { ...options };
+        init.headers = init.headers ? { ...init.headers } : {};
+        if (init.body && !(init.body instanceof FormData)) {
+          init.headers['Content-Type'] = 'application/json';
+        }
+        const response = await fetch(url, init);
+        const text = await response.text();
+        let data = null;
+        if (text) {
+          try { data = JSON.parse(text); } catch (_) { data = null; }
+        }
+        if (!response.ok) {
+          const message = (data && data.error) || response.statusText || 'Onbekende fout';
+          const error = new Error(message);
+          error.status = response.status;
+          error.details = data;
+          throw error;
+        }
+        return data;
+      }
+
+      async function refreshCache() {
+        try {
+          const res = await fetchJson(API_BASE);
+          blogPostsCache = Array.isArray(res?.data) ? res.data : [];
+        } catch (error) {
+          blogPostsCache = [];
+          console.error('Kon blogposts niet laden', error);
+        }
+        return blogPostsCache;
+      }
+
+      async function fetchPostById(id) {
+        if (!id) return null;
+        const res = await fetchJson(`${API_BASE}?id=${encodeURIComponent(id)}`);
+        return res?.data || null;
+      }
+
+      async function upsertPost(payload) {
+        if (editId) {
+          const res = await fetchJson(`${API_BASE}?id=${encodeURIComponent(editId)}`, {
+            method: 'PUT',
+            body: JSON.stringify(payload)
+          });
+          return res?.data || null;
+        }
+        const res = await fetchJson(API_BASE, {
+          method: 'POST',
+          body: JSON.stringify(payload)
+        });
+        return res?.data || null;
+      }
+
+      async function removePost(id) {
+        if (!id) return;
+        await fetchJson(`${API_BASE}?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+      }
+
+      function updateScheduleButtonLabel(status) {
+        if (!scheduleBtn) return;
+        if (status === 'published') {
+          scheduleBtn.textContent = 'Offline zetten';
+        } else if (status === 'offline') {
+          scheduleBtn.textContent = 'Online zetten';
+        } else {
+          scheduleBtn.textContent = 'Inplannen';
+        }
+      }
+
+      function handleError(prefix, error) {
+        console.error(prefix, error);
+        const message = error && error.message ? error.message : 'Onbekende fout';
+        alert(prefix + ': ' + message);
+      }
 
       // --- Editor UX helpers for "In het kort..." box ---
       function normalizeSummaryHeadersInEditor() {
@@ -520,23 +604,33 @@
         }
       });
       
+      await refreshCache();
+      updateSlugHint();
+
       if (editId) {
-        // Load existing blog post for editing
-        const blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        const post = blogPosts.find(p => p.id == editId);
-        
-        if (post) {
-          blogTitle.value = post.title;
-          blogSlug.value = post.slug;
-          blogMetaTitle.value = post.metaTitle;
-          blogMetaDescription.value = post.metaDescription;
-          blogContent.innerHTML = post.content;
+        try {
+          const post = await fetchPostById(editId);
+          if (!post) {
+            alert('Blogpost niet gevonden');
+            window.location.href = '/personeel-dashboard';
+            return;
+          }
+
+          currentPost = post;
+          blogTitle.value = post.title || '';
+          blogSlug.value = post.slug || '';
+          blogMetaTitle.value = post.metaTitle || '';
+          blogMetaDescription.value = post.metaDescription || '';
+          blogContent.innerHTML = post.content || '';
           if (blogDate) {
             var d = post.publishedDate || post.publishDate || '';
-            if (/^\d{4}-\d{2}-\d{2}$/.test(d)) blogDate.value = d;
+            if (/^\d{4}-\d{2}-\d{2}$/.test(d)) {
+              blogDate.value = d;
+            } else {
+              blogDate.value = '';
+            }
           }
-          
-          // Load existing image if available
+
           if (post.featuredImage) {
             const img = document.createElement('img');
             img.src = post.featuredImage;
@@ -544,21 +638,19 @@
             imagePreview.innerHTML = '';
             imagePreview.appendChild(img);
           }
-          
-          // Update page title and actions for edit mode
+
           document.title = 'Bewerk: ' + post.title + ' - Vitalora';
           document.querySelector('.editor-title').textContent = 'Blog Bewerken';
           document.querySelector('.editor-subtitle').textContent = 'Bewerk je bestaande blog post';
           publishBtn.textContent = 'Bijwerken';
           saveDraftBtn.textContent = 'Als concept opslaan';
-          scheduleBtn.textContent = 'Opnieuw inplannen';
           deleteBtn.style.display = 'inline-block';
-          // Add/offline toggle button inline (reuse schedule button label based on status)
-          if (post.status === 'published') {
-            scheduleBtn.textContent = 'Offline zetten';
-          } else if (post.status === 'offline') {
-            scheduleBtn.textContent = 'Online zetten';
-          }
+          updateScheduleButtonLabel(post.status);
+          updateSlugHint();
+        } catch (error) {
+          handleError('Kon blogpost niet laden', error);
+          window.location.href = '/personeel-dashboard';
+          return;
         }
       }
       
@@ -580,24 +672,32 @@
       }
 
       function isUniqueSlug(slug, ignoreId){
-        try {
-          const posts = JSON.parse(localStorage.getItem('vitalora_blog_posts')||'[]');
-          return !posts.some(p => p.slug === slug && String(p.id) !== String(ignoreId||''));
-        } catch(_) { return true; }
+        if (!slug) return true;
+        return !blogPostsCache.some(function(post){
+          return post.slug === slug && String(post.id) !== String(ignoreId || '');
+        });
+      }
+
+      function updateSlugHint(){
+        if (!slugHint) return;
+        const normalized = normalizeSlug(blogSlug.value);
+        if (blogSlug.value !== normalized) {
+          blogSlug.value = normalized;
+        }
+        const ok = isUniqueSlug(blogSlug.value, editId);
+        slugHint.style.color = ok ? '#64748b' : '#ef4444';
+        slugHint.textContent = ok ? 'Uniek, alleen letters/cijfers/koppelteken' : 'Slug is al in gebruik';
       }
 
       blogTitle.addEventListener('blur', function(){
         if(!blogSlug.value.trim()){
           blogSlug.value = normalizeSlug(blogTitle.value);
         }
+        updateSlugHint();
       });
 
       blogSlug.addEventListener('input', function(){
-        const normalized = normalizeSlug(blogSlug.value);
-        if (blogSlug.value !== normalized) blogSlug.value = normalized;
-        const ok = isUniqueSlug(blogSlug.value, editId);
-        slugHint.style.color = ok ? '#64748b' : '#ef4444';
-        slugHint.textContent = ok ? 'Uniek, alleen letters/cijfers/koppelteken' : 'Slug is al in gebruik';
+        updateSlugHint();
       });
 
       // Toolbar functionality
@@ -707,10 +807,10 @@
         return previewImg ? previewImg.src : null;
       }
 
-      // Save as draft (create or update)
-      saveDraftBtn.addEventListener('click', function() {
+      function buildBasePayload(options = {}) {
+        const requireContent = options && options.requireContent === true;
         const title = blogTitle.value.trim();
-        let slug = blogSlug.value.trim();
+        let slugValue = blogSlug.value.trim();
         const metaTitle = blogMetaTitle.value.trim();
         const metaDescription = blogMetaDescription.value.trim();
         const content = blogContent.innerHTML;
@@ -718,243 +818,234 @@
 
         if (!title) {
           alert('Vul de titel in');
-          return;
+          return null;
         }
 
-        if (!slug) {
-          slug = title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
-          blogSlug.value = slug;
-        }
-
-        let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        if (editId) {
-          const index = blogPosts.findIndex(p => p.id == editId);
-          if (index !== -1) {
-            if (!featuredImage && blogPosts[index].featuredImage) {
-              featuredImage = blogPosts[index].featuredImage;
-            }
-            blogPosts[index] = {
-              ...blogPosts[index],
-              title,
-              slug,
-              metaTitle,
-              metaDescription,
-              content,
-              featuredImage,
-              status: 'draft',
-              updatedAt: new Date().toISOString()
-            };
-          }
+        if (!slugValue) {
+          slugValue = normalizeSlug(title);
         } else {
-          const newPost = {
-            id: Date.now(),
-            title,
-            slug,
-            metaTitle,
-            metaDescription,
-            content,
-            featuredImage,
-            status: 'draft',
-            createdAt: new Date().toISOString(),
-            readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200))
-          };
-          blogPosts.unshift(newPost);
+          slugValue = normalizeSlug(slugValue);
         }
 
-        localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-        alert('Concept succesvol opgeslagen!');
-        window.location.href = '/personeel-dashboard';
+        blogSlug.value = slugValue;
+
+        if (!slugValue) {
+          alert('Slug mag niet leeg zijn');
+          updateSlugHint();
+          return null;
+        }
+
+        if (!isUniqueSlug(slugValue, editId)) {
+          alert('Slug is al in gebruik');
+          updateSlugHint();
+          return null;
+        }
+
+        if (requireContent && !content) {
+          alert('Vul de inhoud in');
+          return null;
+        }
+
+        if (!featuredImage && currentPost && currentPost.featuredImage) {
+          featuredImage = currentPost.featuredImage;
+        }
+
+        const plainWords = content
+          .replace(/<[^>]*>/g, ' ')
+          .split(/\s+/)
+          .filter(Boolean);
+        const readTime = Math.max(3, Math.ceil(plainWords.length / 200));
+
+        updateSlugHint();
+
+        return {
+          title,
+          slug: slugValue,
+          metaTitle,
+          metaDescription,
+          content,
+          featuredImage,
+          readTime
+        };
+      }
+
+      // Save as draft (create or update)
+      saveDraftBtn.addEventListener('click', async function() {
+        const base = buildBasePayload();
+        if (!base) return;
+
+        const payload = {
+          ...base,
+          status: 'draft',
+          publishDate: (blogDate && blogDate.value) ? blogDate.value : (currentPost?.publishDate || null),
+          publishedDate: currentPost?.publishedDate || null
+        };
+
+        try {
+          const saved = await upsertPost(payload);
+          if (!saved) throw new Error('Geen antwoord van de server');
+          currentPost = saved;
+          editId = String(saved.id);
+          deleteBtn.style.display = 'inline-block';
+          updateScheduleButtonLabel(saved.status);
+          await refreshCache();
+          updateSlugHint();
+          alert('Concept succesvol opgeslagen!');
+          window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Opslaan mislukt', error);
+        }
       });
-      
+
       // Schedule or toggle offline/online in edit mode
-      scheduleBtn.addEventListener('click', function() {
-        const title = blogTitle.value.trim();
-        let slug = blogSlug.value.trim();
-        const metaTitle = blogMetaTitle.value.trim();
-        const metaDescription = blogMetaDescription.value.trim();
-        const content = blogContent.innerHTML;
-        let featuredImage = getFeaturedImageFromPreview();
+      scheduleBtn.addEventListener('click', async function() {
+        const base = buildBasePayload({ requireContent: true });
+        if (!base) return;
 
-        if (!title || !content) {
-          alert('Vul titel en inhoud in');
-          return;
-        }
+        const buttonText = this.textContent || '';
 
-        // If in edit mode and button says Offline/Online zetten, toggle
-        if (editId && (this.textContent.includes('Offline') || this.textContent.includes('Online'))) {
-          let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-          const index = blogPosts.findIndex(p => p.id == editId);
-          if (index !== -1) {
-            const nextStatus = this.textContent.includes('Offline') ? 'offline' : 'published';
-            blogPosts[index].status = nextStatus;
-            localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
+        if (editId && (buttonText.includes('Offline') || buttonText.includes('Online'))) {
+          const nextStatus = buttonText.includes('Offline') ? 'offline' : 'published';
+          const payload = {
+            ...base,
+            status: nextStatus,
+            publishDate: currentPost?.publishDate || null,
+            publishedDate: currentPost?.publishedDate || null
+          };
+          try {
+            const saved = await upsertPost(payload);
+            if (!saved) throw new Error('Geen antwoord van de server');
+            currentPost = saved;
+            editId = String(saved.id);
+            updateScheduleButtonLabel(saved.status);
+            await refreshCache();
+            updateSlugHint();
             alert(nextStatus === 'offline' ? 'Blog offline gezet' : 'Blog online gezet');
             window.location.href = '/personeel-dashboard';
-            return;
+          } catch (error) {
+            handleError('Status bijwerken mislukt', error);
           }
+          return;
         }
 
         const scheduleDate = (blogDate && blogDate.value) ? blogDate.value : prompt('Voer datum (YYYY-MM-DD):');
         if (!scheduleDate) return;
 
-        if (!slug) {
-          slug = title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
-          blogSlug.value = slug;
-        }
+        const payload = {
+          ...base,
+          status: 'scheduled',
+          publishDate: scheduleDate,
+          publishedDate: null
+        };
 
-        let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        if (editId) {
-          const index = blogPosts.findIndex(p => p.id == editId);
-          if (index !== -1) {
-            if (!featuredImage && blogPosts[index].featuredImage) {
-              featuredImage = blogPosts[index].featuredImage;
-            }
-            blogPosts[index] = {
-              ...blogPosts[index],
-              title,
-              slug,
-              metaTitle,
-              metaDescription,
-              content,
-              featuredImage,
-              status: 'scheduled',
-              publishDate: scheduleDate,
-              updatedAt: new Date().toISOString()
-            };
-          }
-        } else {
-          const newPost = {
-            id: Date.now(),
-            title,
-            slug,
-            metaTitle,
-            metaDescription,
-            content,
-            featuredImage,
-            status: 'scheduled',
-            publishDate: scheduleDate,
-            createdAt: new Date().toISOString(),
-            readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200))
-          };
-          blogPosts.unshift(newPost);
+        try {
+          const saved = await upsertPost(payload);
+          if (!saved) throw new Error('Geen antwoord van de server');
+          currentPost = saved;
+          editId = String(saved.id);
+          deleteBtn.style.display = 'inline-block';
+          updateScheduleButtonLabel(saved.status);
+          await refreshCache();
+          updateSlugHint();
+          alert('Blog succesvol ingepland!');
+          window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Inplannen mislukt', error);
         }
-
-        localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-        alert('Blog succesvol ingepland!');
-        window.location.href = '/personeel-dashboard';
       });
-      
+
       // Publish blog
-      publishBtn.addEventListener('click', function() {
-        const title = blogTitle.value.trim();
-        const slug = blogSlug.value.trim();
-        const metaTitle = blogMetaTitle.value.trim();
-        const metaDescription = blogMetaDescription.value.trim();
-        const content = blogContent.innerHTML;
-        let featuredImage = getFeaturedImageFromPreview();
-        
-        if (!title || !content) {
-          alert('Vul titel en inhoud in');
+      publishBtn.addEventListener('click', async function() {
+        const base = buildBasePayload({ requireContent: true });
+        if (!base) return;
+
+        if (!confirm('Weet je zeker dat je deze blog post wilt publiceren?')) {
           return;
         }
-        
-        if (confirm('Weet je zeker dat je deze blog post wilt publiceren?')) {
-          // Get existing blog posts
-          let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-          
-          if (editId) {
-            // Update existing blog post
-            const postIndex = blogPosts.findIndex(p => p.id == editId);
-            if (postIndex !== -1) {
-              const existing = blogPosts[postIndex];
-              if (!featuredImage && existing.featuredImage) {
-                featuredImage = existing.featuredImage;
-              }
-              blogPosts[postIndex] = {
-                ...existing,
-                title,
-                slug: slug, // Always use the new slug value
-                metaTitle,
-                metaDescription,
-                content,
-                featuredImage,
-                status: 'published',
-                publishedDate: (blogDate && blogDate.value) ? blogDate.value : (existing.publishedDate || new Date().toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' })),
-                readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200)),
-                updatedAt: new Date().toISOString()
-              };
-              alert('Blog succesvol bijgewerkt!');
-            }
+
+        const wasExisting = Boolean(editId);
+        let publishedDate = (blogDate && blogDate.value) ? blogDate.value : null;
+        if (!publishedDate) {
+          if (currentPost && currentPost.publishedDate) {
+            publishedDate = currentPost.publishedDate;
           } else {
-            // Create new blog post
-            const blogPost = {
-              id: Date.now(),
-              title: title,
-              slug: slug,
-              metaTitle: metaTitle,
-              metaDescription: metaDescription,
-              content: content,
-              featuredImage: featuredImage,
-              status: 'published',
-              publishedDate: (blogDate && blogDate.value) ? blogDate.value : new Date().toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' }),
-              readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200))
-            };
-            
-            // Add new blog post
-            blogPosts.unshift(blogPost);
-            alert('Blog succesvol gepubliceerd!');
+            publishedDate = new Date().toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' });
           }
-          
-          // Save back to localStorage
-          localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-          
-          console.log('Publishing blog:', blogPosts[editId ? blogPosts.findIndex(p => p.id == editId) : 0]);
+        }
+
+        const payload = {
+          ...base,
+          status: 'published',
+          publishDate: null,
+          publishedDate
+        };
+
+        try {
+          const saved = await upsertPost(payload);
+          if (!saved) throw new Error('Geen antwoord van de server');
+          currentPost = saved;
+          editId = String(saved.id);
+          deleteBtn.style.display = 'inline-block';
+          updateScheduleButtonLabel(saved.status);
+          await refreshCache();
+          updateSlugHint();
+          alert(wasExisting ? 'Blog succesvol bijgewerkt!' : 'Blog succesvol gepubliceerd!');
           window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Publiceren mislukt', error);
         }
       });
 
       // Delete blog
-      deleteBtn.addEventListener('click', function(){
+      deleteBtn.addEventListener('click', async function(){
         if(!editId){ return; }
         if(!confirm('Weet je zeker dat je deze blog wilt verwijderen?')) return;
-        let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        blogPosts = blogPosts.filter(p => p.id != editId);
-        localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-        alert('Blog verwijderd');
-        window.location.href = '/personeel-dashboard';
+        try {
+          await removePost(editId);
+          alert('Blog verwijderd');
+          window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Verwijderen mislukt', error);
+        }
       });
-      
+
       // Preview opens post.html with current slug in new tab
       const previewBtn = document.getElementById('preview-blog');
       if (previewBtn) {
-        previewBtn.addEventListener('click', function(){
+        previewBtn.addEventListener('click', async function(){
           const slug = normalizeSlug(blogSlug.value || blogTitle.value);
           if(!slug){ alert('Vul eerst titel of slug in'); return; }
-          // ensure current changes are reflected for preview: save draft temporarily in storage
+          blogSlug.value = slug;
+
+          const base = buildBasePayload();
+          if (!base) return;
+
+          const payload = {
+            ...base,
+            slug,
+            status: currentPost?.status || 'draft',
+            publishDate: (blogDate && blogDate.value) ? blogDate.value : (currentPost?.publishDate || null),
+            publishedDate: currentPost?.publishedDate || null
+          };
+
           try {
-            let posts = JSON.parse(localStorage.getItem('vitalora_blog_posts')||'[]');
-            const idx = editId ? posts.findIndex(p=>String(p.id)===String(editId)) : -1;
-            const doc = {
-              id: editId || Date.now(),
-              title: blogTitle.value.trim() || slug,
-              slug: slug,
-              metaTitle: blogMetaTitle.value.trim(),
-              metaDescription: blogMetaDescription.value.trim(),
-              content: blogContent.innerHTML,
-              featuredImage: (function(){
-                const img= document.getElementById('image-preview')?.querySelector('img');
-                return img? img.src : (idx>=0 && posts[idx] && posts[idx].featuredImage) ? posts[idx].featuredImage : null;
-              })(),
-              status: (idx>=0 && posts[idx].status) || 'draft',
-              updatedAt: new Date().toISOString()
-            };
-            if (idx>=0) { posts[idx]= { ...posts[idx], ...doc }; } else { posts.unshift(doc); }
-            localStorage.setItem('vitalora_blog_posts', JSON.stringify(posts));
-          } catch(_){}
+            const saved = await upsertPost(payload);
+            if (!saved) throw new Error('Geen antwoord van de server');
+            currentPost = saved;
+            editId = String(saved.id);
+            deleteBtn.style.display = 'inline-block';
+            updateScheduleButtonLabel(saved.status);
+            await refreshCache();
+            updateSlugHint();
+          } catch (error) {
+            handleError('Opslaan voor preview mislukt', error);
+            return;
+          }
+
           window.open('/post.html?slug=' + encodeURIComponent(slug), '_blank');
         });
       }
-      
+
     })();
   </script>
 </body>

--- a/personeel-dashboard.html
+++ b/personeel-dashboard.html
@@ -114,8 +114,37 @@
 
   <script>
     (function(){
-      const key='staff_access_ok';
-      if(localStorage.getItem(key)!=='1'){ window.location.href='/personeel'; return; }
+      function hasStaffAccess(){
+        return document.cookie.split(';').some(function(part){
+          return part.trim().startsWith('staff_access_ok=');
+        });
+      }
+
+      if(!hasStaffAccess()){ window.location.href='/personeel'; return; }
+
+      const API_BASE = '/api/blogs';
+
+      async function fetchJson(url, options = {}){
+        const init = { ...options };
+        init.headers = init.headers ? { ...init.headers } : {};
+        if (init.body && !(init.body instanceof FormData)) {
+          init.headers['Content-Type'] = 'application/json';
+        }
+        const response = await fetch(url, init);
+        const text = await response.text();
+        let data = null;
+        if (text) {
+          try { data = JSON.parse(text); } catch (_) { data = null; }
+        }
+        if (!response.ok) {
+          const message = (data && data.error) || response.statusText || 'Onbekende fout';
+          const error = new Error(message);
+          error.status = response.status;
+          error.details = data;
+          throw error;
+        }
+        return data;
+      }
       // Revenue fetch
       async function loadRevenue(){
         try{
@@ -132,94 +161,107 @@
       loadRevenue();
       setInterval(loadRevenue, 60000);
       
+
+      function escapeHtml(value){
+        return String(value || '').replace(/[&<>"']/g, function(char){
+          return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[char];
+        });
+      }
+
       // Load and display blog posts in the table
-      function loadBlogPosts() {
-        const blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
+      async function loadBlogPosts() {
         const tableBody = document.getElementById('blog-posts-table');
-        
+
         if (!tableBody) return;
-        
-        // Clear existing rows
-        tableBody.innerHTML = '';
-        
-        if (blogPosts.length === 0) {
-          tableBody.innerHTML = '<tr><td colspan="2" style="text-align: center; color: #6b7280; padding: 20px;">Geen blog posts gevonden</td></tr>';
-          return;
-        }
-        
-        // Add each blog post as a table row
-        blogPosts.forEach(function(post) {
-          const row = document.createElement('tr');
-          row.style.cursor = 'pointer';
-          row.onclick = function() {
-            // Open blog editor for editing
-            window.open('/blog-editor.html?edit=' + post.id, '_blank');
-          };
-          
-          const statusMap = {
-            published: {label:'Gepubliceerd', bg:'#10b981'},
-            draft: {label:'Concept', bg:'#6b7280'},
-            scheduled: {label:'Ingepland', bg:'#f59e0b'},
-            offline: {label:'Offline', bg:'#ef4444'}
-          };
-          const meta = statusMap[post.status] || statusMap.published;
-          row.innerHTML = `
-            <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; color: #333333;">${post.title}</td>
+
+        tableBody.innerHTML = '<tr><td colspan="3" style="text-align: center; color: #6b7280; padding: 20px;">Laden...</td></tr>';
+
+        try {
+          const res = await fetchJson(API_BASE);
+          const blogPosts = Array.isArray(res?.data) ? res.data : [];
+
+          tableBody.innerHTML = '';
+
+          if (!blogPosts.length) {
+            tableBody.innerHTML = '<tr><td colspan="3" style="text-align: center; color: #6b7280; padding: 20px;">Geen blog posts gevonden</td></tr>';
+            return;
+          }
+
+          blogPosts.forEach(function(post) {
+            const row = document.createElement('tr');
+            row.style.cursor = 'pointer';
+            row.onclick = function() {
+              window.open('/blog-editor.html?edit=' + encodeURIComponent(post.id), '_blank');
+            };
+
+            const statusMap = {
+              published: {label:'Gepubliceerd', bg:'#10b981'},
+              draft: {label:'Concept', bg:'#6b7280'},
+              scheduled: {label:'Ingepland', bg:'#f59e0b'},
+              offline: {label:'Offline', bg:'#ef4444'}
+            };
+            const meta = statusMap[post.status] || statusMap.published;
+            const safeTitle = escapeHtml(post.title || 'Zonder titel');
+
+            row.innerHTML = `
+            <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; color: #333333;">${safeTitle}</td>
             <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; color: #333333;">
               <span style="background: ${meta.bg}; color: white; padding: 4px 8px; border-radius: 12px; font-size: 12px; font-weight: 600;">
                 ${meta.label}
               </span>
             </td>
             <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; text-align:right; white-space:nowrap;">
-              <button class="view-post" data-id="${post.id}" aria-label="Bekijken" title="Bekijken" style="background:transparent;border:0;color:#3A9AEA;cursor:pointer;padding:6px;border-radius:6px;margin-right:6px;">
+              <button class="view-post" aria-label="Bekijken" title="Bekijken" style="background:transparent;border:0;color:#3A9AEA;cursor:pointer;padding:6px;border-radius:6px;margin-right:6px;">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                   <path d="M12 5c-7 0-11 7-11 7s4 7 11 7 11-7 11-7-4-7-11-7zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 .001 6.001A3 3 0 0 0 12 9z"/>
                 </svg>
               </button>
-              <button class="delete-post" data-id="${post.id}" aria-label="Verwijderen" title="Verwijderen" style="background:transparent;border:0;color:#ef4444;cursor:pointer;padding:6px;border-radius:6px;">
+              <button class="delete-post" aria-label="Verwijderen" title="Verwijderen" style="background:transparent;border:0;color:#ef4444;cursor:pointer;padding:6px;border-radius:6px;">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                   <path d="M9 3h6a1 1 0 0 1 1 1v1h5v2h-1v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7H3V5h5V4a1 1 0 0 1 1-1zm1 2v0h4V5h-4zM6 7v12h12V7H6zm4 2h2v8h-2V9zm-4 0h2v8H6V9zm10 0h-2v8h2V9z"/>
                 </svg>
               </button>
             </td>
           `;
-          // Hook delete button
-          const del = row.querySelector('.delete-post');
-          if (del) {
-            del.addEventListener('click', function(ev){
-              ev.stopPropagation();
-              const id = this.getAttribute('data-id');
-              if (!id) return;
-              if (!confirm('Weet je zeker dat je deze blog wilt verwijderen?')) return;
-              let list = [];
-              try { list = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]'); } catch(_) {}
-              list = list.filter(function(p){ return String(p.id) !== String(id); });
-              localStorage.setItem('vitalora_blog_posts', JSON.stringify(list));
-              loadBlogPosts();
-            });
-          }
-          
-          // Hook view button
-          const viewBtn = row.querySelector('.view-post');
-          if (viewBtn) {
-            viewBtn.addEventListener('click', function(ev){
-              ev.stopPropagation();
-              const id = this.getAttribute('data-id');
-              let list = [];
-              try { list = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]'); } catch(_) {}
-              const post = list.find(function(p){ return String(p.id) === String(id); });
-              if (!post) return;
-              const slug = post.slug || '';
-              const status = post.status || 'published';
-              const url = status === 'published' ? ('/' + encodeURIComponent(slug)) : ('/post.html?slug=' + encodeURIComponent(slug));
-              window.open(url, '_blank');
-            });
-          }
-          
-          tableBody.appendChild(row);
-        });
+
+            const del = row.querySelector('.delete-post');
+            if (del) {
+              del.addEventListener('click', async function(ev){
+                ev.stopPropagation();
+                if (!confirm('Weet je zeker dat je deze blog wilt verwijderen?')) return;
+                try {
+                  await fetchJson(`${API_BASE}?id=${encodeURIComponent(post.id)}`, { method: 'DELETE' });
+                  await loadBlogPosts();
+                } catch (error) {
+                  alert('Verwijderen mislukt: ' + (error && error.message ? error.message : 'Onbekende fout'));
+                }
+              });
+            }
+
+            const viewBtn = row.querySelector('.view-post');
+            if (viewBtn) {
+              viewBtn.addEventListener('click', function(ev){
+                ev.stopPropagation();
+                const slug = post.slug || '';
+                if (!slug) {
+                  window.open('/blog-editor.html?edit=' + encodeURIComponent(post.id), '_blank');
+                  return;
+                }
+                const status = post.status || 'published';
+                const url = status === 'published' ? ('/' + encodeURIComponent(slug)) : ('/post.html?slug=' + encodeURIComponent(slug));
+                window.open(url, '_blank');
+              });
+            }
+
+            tableBody.appendChild(row);
+          });
+        } catch (error) {
+          const message = error && error.message ? error.message : 'Onbekende fout';
+          tableBody.innerHTML = '<tr><td colspan="3" style="text-align: center; color: #ef4444; padding: 20px;">Fout bij laden: ' + escapeHtml(message) + '</td></tr>';
+        }
       }
-      
+
+// No extra actions here; only listing and create button per verzoek
       // No extra actions here; only listing and create button per verzoek
       
       // Load blog posts when page loads

--- a/personeel.html
+++ b/personeel.html
@@ -99,7 +99,7 @@
       enterButton.addEventListener('click', function(){
         const code = Array.from(pinInputs).map(input => input.value).join('');
         if(code === '248911') {
-          localStorage.setItem('staff_access_ok','1');
+          document.cookie = 'staff_access_ok=1; path=/; max-age=86400';
           window.location.href = '/personeel-dashboard';
         } else {
           errorDiv.textContent = 'Ongeldige code.';


### PR DESCRIPTION
## Summary
- add a serverless `/api/blogs` endpoint that persists blog posts in a SQLite database via the sqlite3 CLI
- update the blog editor and staff dashboard to load, save, publish, schedule and delete posts through the new API instead of localStorage
- store the staff access flag in a cookie so the editor and dashboard can check access without relying on localStorage

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c93dcfc83c8329a6053aab302f4ff7