### PR TITLE
Implement server-side staff authentication

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -50,4 +50,4 @@
 /checkout.html                            /checkout                                  301
 /artikelen                               /blog                                      301
 /personeel                               /personeel.html                            200
-/personeel-dashboard                     /personeel-dashboard.html                  200
+/personeel-dashboard                     /api/personeel-dashboard                   200

--- a/_redirects.backup
+++ b/_redirects.backup
@@ -23,4 +23,4 @@
 /checkout           /wacht-even      301
 /artikelen          /blog            301
 /personeel            /personeel.html       200
-/personeel-dashboard  /personeel-dashboard.html  200
+/personeel-dashboard  /api/personeel-dashboard  200

--- a/api/_utils/auth.js
+++ b/api/_utils/auth.js
@@ -1,0 +1,154 @@
+const crypto = require('crypto');
+
+const DEFAULT_SESSION_TTL_MS = 1000 * 60 * 60 * 8; // 8 hours
+const SECRET = process.env.STAFF_AUTH_SECRET || process.env.AUTH_SECRET || 'change-me-in-production';
+const COOKIE_NAME = 'staff_session';
+
+function signPayload(payload, secret = SECRET) {
+  const base = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = crypto.createHmac('sha256', secret).update(base).digest('base64url');
+  return `${base}.${signature}`;
+}
+
+function verifySignature(base, signature, secret = SECRET) {
+  const expected = crypto.createHmac('sha256', secret).update(base).digest('base64url');
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const receivedBuf = Buffer.from(signature || '', 'utf8');
+  if (expectedBuf.length !== receivedBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(expectedBuf, receivedBuf);
+}
+
+function createSessionToken({ sub = 'staff', ttlMs = DEFAULT_SESSION_TTL_MS } = {}) {
+  const now = Date.now();
+  const payload = {
+    sub: String(sub || 'staff'),
+    type: 'staff',
+    iat: now,
+    exp: now + Math.max(Number(ttlMs) || DEFAULT_SESSION_TTL_MS, 0),
+    ver: 1,
+  };
+  return signPayload(payload);
+}
+
+function verifySessionToken(token) {
+  if (!token || typeof token !== 'string' || token.split('.').length !== 2) {
+    return null;
+  }
+  const [base, signature] = token.split('.');
+  if (!verifySignature(base, signature)) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(Buffer.from(base, 'base64url').toString('utf8'));
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+    if (payload.exp && Date.now() > Number(payload.exp)) {
+      return null;
+    }
+    return payload;
+  } catch (_) {
+    return null;
+  }
+}
+
+function parseCookies(req) {
+  const header = req?.headers?.cookie || req?.headers?.Cookie || '';
+  if (!header) return {};
+  return header.split(';').reduce((acc, part) => {
+    const [key, ...rest] = part.trim().split('=');
+    if (!key) return acc;
+    acc[key] = decodeURIComponent(rest.join('=') || '');
+    return acc;
+  }, {});
+}
+
+function getSessionFromRequest(req) {
+  const cookies = parseCookies(req);
+  const token = cookies[COOKIE_NAME];
+  return verifySessionToken(token);
+}
+
+function buildCookie(parts) {
+  return parts.filter(Boolean).join('; ');
+}
+
+function setSessionCookie(res, token, { maxAgeSeconds, sameSite = 'Strict' } = {}) {
+  const maxAge = typeof maxAgeSeconds === 'number' ? maxAgeSeconds : Math.floor(DEFAULT_SESSION_TTL_MS / 1000);
+  const secure = process.env.NODE_ENV !== 'development';
+  const cookie = buildCookie([
+    `${COOKIE_NAME}=${token}`,
+    'Path=/',
+    'HttpOnly',
+    `Max-Age=${Math.max(0, maxAge)}`,
+    `SameSite=${sameSite}`,
+    secure ? 'Secure' : null,
+  ]);
+  res.setHeader('Set-Cookie', cookie);
+}
+
+function clearSessionCookie(res) {
+  const secure = process.env.NODE_ENV !== 'development';
+  const cookie = buildCookie([
+    `${COOKIE_NAME}=`,
+    'Path=/',
+    'HttpOnly',
+    'Max-Age=0',
+    'SameSite=Strict',
+    secure ? 'Secure' : null,
+  ]);
+  res.setHeader('Set-Cookie', cookie);
+}
+
+async function readBody(req) {
+  if (req.body && typeof req.body === 'object' && !Buffer.isBuffer(req.body)) {
+    return req.body;
+  }
+
+  let raw = '';
+  if (req.body && typeof req.body === 'string') {
+    raw = req.body;
+  } else {
+    raw = await new Promise((resolve, reject) => {
+      let data = '';
+      req.on('data', (chunk) => {
+        data += chunk;
+      });
+      req.on('end', () => resolve(data));
+      req.on('error', reject);
+    });
+  }
+
+  const contentType = req.headers?.['content-type'] || req.headers?.['Content-Type'] || '';
+  if (!raw) {
+    return {};
+  }
+
+  if (contentType.includes('application/json')) {
+    try {
+      return JSON.parse(raw);
+    } catch (_) {
+      return {};
+    }
+  }
+
+  const params = new URLSearchParams(raw);
+  const body = {};
+  for (const [key, value] of params.entries()) {
+    body[key] = value;
+  }
+  return body;
+}
+
+module.exports = {
+  COOKIE_NAME,
+  createSessionToken,
+  verifySessionToken,
+  parseCookies,
+  getSessionFromRequest,
+  setSessionCookie,
+  clearSessionCookie,
+  readBody,
+};

--- a/api/customers.js
+++ b/api/customers.js
@@ -1,6 +1,13 @@
-export default async function handler(req, res) {
+const { getSessionFromRequest } = require('./_utils/auth.js');
+
+async function handler(req, res) {
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    res.status(401).json({ error: 'Niet geautoriseerd' });
     return;
   }
   const apiKey = process.env.MOLLIE_API_KEY;
@@ -86,5 +93,7 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Unexpected server error', details: String(e) });
   }
 }
+
+module.exports = handler;
 
 

--- a/api/orders-summary.js
+++ b/api/orders-summary.js
@@ -1,6 +1,14 @@
-export default async function handler(req, res) {
+const { getSessionFromRequest } = require('./_utils/auth.js');
+
+async function handler(req, res) {
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    res.status(401).json({ error: 'Niet geautoriseerd' });
     return;
   }
 
@@ -74,5 +82,7 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Unexpected server error', details: String(err) });
   }
 }
+
+module.exports = handler;
 
 

--- a/api/personeel-dashboard.js
+++ b/api/personeel-dashboard.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const { getSessionFromRequest } = require('./_utils/auth.js');
+
+const DASHBOARD_PATH = path.join(process.cwd(), 'protected', 'personeel-dashboard.html');
+
+async function readDashboardTemplate() {
+  return fs.promises.readFile(DASHBOARD_PATH, 'utf8');
+}
+
+async function handler(req, res) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD');
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    res.statusCode = 302;
+    res.setHeader('Location', '/personeel');
+    res.end('Found');
+    return;
+  }
+
+  try {
+    const html = await readDashboardTemplate();
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    if (req.method === 'HEAD') {
+      res.status(200).end();
+      return;
+    }
+    res.status(200).end(html);
+  } catch (err) {
+    res.status(500).setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.end('Kon dashboard niet laden.');
+  }
+}
+
+module.exports = handler;

--- a/api/staff-login.js
+++ b/api/staff-login.js
@@ -1,0 +1,62 @@
+const crypto = require('crypto');
+const {
+  createSessionToken,
+  setSessionCookie,
+  clearSessionCookie,
+  readBody,
+} = require('./_utils/auth.js');
+
+function safeCompare(a, b) {
+  const valA = Buffer.from(String(a ?? ''), 'utf8');
+  const valB = Buffer.from(String(b ?? ''), 'utf8');
+  if (valA.length !== valB.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(valA, valB);
+}
+
+function passwordMatches(password) {
+  const expectedHash = process.env.STAFF_PASSWORD_HASH;
+  if (expectedHash) {
+    const hash = crypto.createHash('sha256').update(String(password || '')).digest('hex');
+    return safeCompare(hash, expectedHash);
+  }
+  const expectedPlain = process.env.STAFF_PASSWORD || process.env.STAFF_PIN || '248911';
+  return safeCompare(String(password || ''), expectedPlain);
+}
+
+async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const body = await readBody(req);
+    const username = String(body?.username || body?.email || '').trim();
+    const password = body?.password || body?.pin || '';
+
+    if (!username || !password) {
+      clearSessionCookie(res);
+      res.status(400).json({ error: 'Vul zowel gebruikersnaam als wachtwoord in.' });
+      return;
+    }
+
+    const expectedUsername = process.env.STAFF_USERNAME || process.env.STAFF_USER || 'vitalora';
+    if (!safeCompare(username.toLowerCase(), expectedUsername.toLowerCase()) || !passwordMatches(password)) {
+      clearSessionCookie(res);
+      res.status(401).json({ error: 'Ongeldige inloggegevens.' });
+      return;
+    }
+
+    const token = createSessionToken({ sub: username });
+    setSessionCookie(res, token);
+    res.status(200).json({ success: true, redirect: '/personeel-dashboard' });
+  } catch (err) {
+    clearSessionCookie(res);
+    res.status(500).json({ error: 'Er is een fout opgetreden bij het inloggen.' });
+  }
+}
+
+module.exports = handler;

--- a/klanten.html
+++ b/klanten.html
@@ -51,7 +51,7 @@
     <nav class="sidenav">
       <h4>MENU</h4>
       <div class="navlist">
-        <a href="/personeel-dashboard.html">Overzicht</a>
+        <a href="/personeel-dashboard">Overzicht</a>
         <a href="/klanten.html" class="active">Klanten</a>
       </div>
     </nav>
@@ -84,8 +84,12 @@
       const body = document.getElementById('customers-body');
       try{
         body.innerHTML = '<tr><td colspan="3" style="color:#64748b;padding:16px">Laden…</td></tr>';
-        const res = await fetch('/api/customers');
-        const data = await res.json();
+        const res = await fetch('/api/customers', { headers: { 'Accept': 'application/json' } });
+        if(res.status === 401 || res.status === 403){
+          window.location.href = '/personeel';
+          return;
+        }
+        const data = await res.json().catch(() => ({}));
         if(!res.ok) throw new Error(JSON.stringify(data));
         function fmt(v){ return '€ ' + Number(v||0).toFixed(2).replace('.', ','); }
         if(!data.customers || data.customers.length===0){

--- a/personeel.html
+++ b/personeel.html
@@ -17,13 +17,15 @@
     .staff-card{max-width:420px;width:100%;background:rgba(255,255,255,0.95);backdrop-filter:blur(20px);border-radius:20px;box-shadow:0 20px 50px rgba(0,0,0,0.3);padding:40px;border:none}
     .staff-card h1{font-size:24px;margin-bottom:10px;color:#333;font-weight:600}
     .staff-card p{color:#666;margin-bottom:24px;font-size:16px}
-    .pin-container{display:flex;gap:10px;justify-content:center;margin-bottom:20px;margin-top:-6px}
-    .pin-input{width:46px;height:46px;border:2px solid #e5e7eb;border-radius:10px;text-align:center;font-size:20px;font-weight:700;color:#333;background:#fff;transition:border-color .3s ease, box-shadow .3s ease}
-    .pin-input:focus{outline:none;border-color:#2954B3;box-shadow:0 0 0 3px rgba(41,84,179,0.12)}
-    .pin-input.filled{border-color:#2954B3;background:#f8fafc}
+    .staff-form{display:flex;flex-direction:column;gap:16px;margin-top:-6px}
+    .form-field{display:flex;flex-direction:column;gap:6px}
+    .form-field label{font-size:14px;color:#4b5563;font-weight:600}
+    .staff-input{border:2px solid #e5e7eb;border-radius:10px;padding:12px 14px;font-size:16px;font-weight:600;color:#111827;background:#fff;transition:border-color .3s ease, box-shadow .3s ease}
+    .staff-input:focus{outline:none;border-color:#2954B3;box-shadow:0 0 0 3px rgba(41,84,179,0.12)}
     .staff-card button{width:100%;background:linear-gradient(135deg,#2954B3 0%,#1e3a8a 100%);color:#fff;border:0;border-radius:10px;padding:14px 16px;font-weight:700;cursor:pointer;transition:transform .2s ease, box-shadow .2s ease}
     .staff-card button:hover{transform:translateY(-2px);box-shadow:0 8px 25px rgba(41,84,179,0.3)}
     .staff-card button:active{transform:none}
+    .staff-card button:disabled{opacity:0.7;cursor:not-allowed;box-shadow:none;transform:none}
     .staff-error{color:#ef4444;min-height:18px;margin-bottom:8px;text-align:center}
     .back-link{color:#666;text-decoration:none;font-size:14px;transition:color .3s ease;margin-top:20px;display:inline-block}
     .back-link:hover{color:#2954B3}
@@ -36,76 +38,69 @@
   <main class="staff-gate">
     <div class="staff-card">
       <h1>Personeel</h1>
-      <p>Voer de personeelscode in om naar het interne dashboard te gaan.</p>
-      <div id="err" class="staff-error"></div>
-      <div class="pin-container">
-        <input type="text" class="pin-input" maxlength="1" inputmode="numeric" />
-        <input type="text" class="pin-input" maxlength="1" inputmode="numeric" />
-        <input type="text" class="pin-input" maxlength="1" inputmode="numeric" />
-        <input type="text" class="pin-input" maxlength="1" inputmode="numeric" />
-        <input type="text" class="pin-input" maxlength="1" inputmode="numeric" />
-        <input type="text" class="pin-input" maxlength="1" inputmode="numeric" />
-      </div>
-      <button id="enter">Naar dashboard</button>
+      <p>Log in met je personeelsgegevens om toegang te krijgen tot het interne dashboard.</p>
+      <div id="err" class="staff-error" role="alert"></div>
+      <form id="login-form" class="staff-form" novalidate>
+        <div class="form-field">
+          <label for="username">Gebruikersnaam</label>
+          <input type="text" id="username" name="username" class="staff-input" autocomplete="username" required autofocus />
+        </div>
+        <div class="form-field">
+          <label for="password">Wachtwoord</label>
+          <input type="password" id="password" name="password" class="staff-input" autocomplete="current-password" required />
+        </div>
+        <button type="submit" id="submit-btn">Inloggen</button>
+      </form>
       <a href="/" class="back-link">← Terug naar homepage</a>
     </div>
   </main>
 
   <script>
     (function(){
-      const pinInputs = document.querySelectorAll('.pin-input');
-      const enterButton = document.getElementById('enter');
+      const form = document.getElementById('login-form');
       const errorDiv = document.getElementById('err');
-      
-      // Auto-focus first input
-      pinInputs[0].focus();
-      
-      // Handle input in each PIN field
-      pinInputs.forEach((input, index) => {
-        input.addEventListener('input', function(e) {
-          // Only allow numbers
-          this.value = this.value.replace(/[^0-9]/g, '');
-          
-          // Move to next input if current is filled
-          if (this.value && index < pinInputs.length - 1) {
-            pinInputs[index + 1].focus();
+      const submitButton = document.getElementById('submit-btn');
+      if(!form || !submitButton) return;
+
+      const defaultButtonText = submitButton.textContent;
+
+      form.addEventListener('submit', async function(event){
+        event.preventDefault();
+        if (errorDiv) errorDiv.textContent = '';
+
+        submitButton.disabled = true;
+        submitButton.textContent = 'Bezig met inloggen…';
+
+        try {
+          const formData = new FormData(form);
+          const payload = new URLSearchParams();
+          for (const [key, value] of formData.entries()) {
+            payload.append(key, typeof value === 'string' ? value.trim() : value);
           }
-        });
-        
-        input.addEventListener('keydown', function(e) {
-          // Handle backspace
-          if (e.key === 'Backspace' && !this.value && index > 0) {
-            pinInputs[index - 1].focus();
+
+          const response = await fetch('/api/staff-login', {
+            method: 'POST',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+            },
+            body: payload.toString()
+          });
+
+          const data = await response.json().catch(() => ({}));
+
+          if (response.ok && data && data.success) {
+            window.location.href = data.redirect || '/personeel-dashboard';
+            return;
           }
-          
-          // Handle enter key
-          if (e.key === 'Enter') {
-            enterButton.click();
-          }
-        });
-        
-        input.addEventListener('paste', function(e) {
-          e.preventDefault();
-          const pastedData = e.clipboardData.getData('text').replace(/[^0-9]/g, '');
-          for (let i = 0; i < Math.min(pastedData.length, pinInputs.length); i++) {
-            pinInputs[i].value = pastedData[i];
-          }
-          // Focus last filled input or last input
-          const lastFilledIndex = Math.min(pastedData.length - 1, pinInputs.length - 1);
-          pinInputs[lastFilledIndex].focus();
-        });
-      });
-      
-      enterButton.addEventListener('click', function(){
-        const code = Array.from(pinInputs).map(input => input.value).join('');
-        if(code === '248911') {
-          localStorage.setItem('staff_access_ok','1');
-          window.location.href = '/personeel-dashboard';
-        } else {
-          errorDiv.textContent = 'Ongeldige code.';
-          // Clear all inputs and focus first
-          pinInputs.forEach(input => input.value = '');
-          pinInputs[0].focus();
+
+          const message = (data && data.error) ? data.error : 'Inloggen mislukt. Controleer je gegevens en probeer het opnieuw.';
+          if (errorDiv) errorDiv.textContent = message;
+        } catch (err) {
+          if (errorDiv) errorDiv.textContent = 'Er is een fout opgetreden. Probeer het later opnieuw.';
+        } finally {
+          submitButton.disabled = false;
+          submitButton.textContent = defaultButtonText;
         }
       });
     })();

--- a/protected/personeel-dashboard.html
+++ b/protected/personeel-dashboard.html
@@ -114,12 +114,16 @@
 
   <script>
     (function(){
-      const key='staff_access_ok';
-      if(localStorage.getItem(key)!=='1'){ window.location.href='/personeel'; return; }
       // Revenue fetch
       async function loadRevenue(){
         try{
-          const res = await fetch('/api/orders-summary');
+          const res = await fetch('/api/orders-summary', {
+            headers: { 'Accept': 'application/json' }
+          });
+          if(res.status === 401 || res.status === 403){
+            window.location.href = '/personeel';
+            return;
+          }
           const data = await res.json();
           if(!res.ok) throw new Error(JSON.stringify(data));
           function fmt(v){ return '€ ' + (Number(v||0).toFixed(2)).replace('.', ','); }

--- a/vercel.json
+++ b/vercel.json
@@ -32,7 +32,8 @@
     { "source": "/everyday-nutrition-praktisch-gezond", "destination": "/course-view.html?course=everyday-nutrition-praktisch-gezond" },
     { "source": "/powerfoods-superfood-specerij", "destination": "/course-view.html?course=powerfoods-superfood-specerij" },
     { "source": "/30-dagen-challenge", "destination": "/course-view.html?course=30-dagen-challenge" }
-    ,{ "source": "/personeel-dashboard", "destination": "/personeel-dashboard.html" }
+    ,{ "source": "/personeel-dashboard", "destination": "/api/personeel-dashboard" }
+    ,{ "source": "/personeel-dashboard.html", "destination": "/api/personeel-dashboard" }
     ,{ "source": "/peren-gezond", "destination": "/post.html?slug=peren-gezond" }
     ,{ "source": "/mango-gezond", "destination": "/post.html?slug=mango-gezond" }
     ,{ "source": "/aardbeien-gezond", "destination": "/aardbeien-gezond.html" }


### PR DESCRIPTION
## Summary
- Replace the client-side personeelscode check with a credential form that submits to a new staff login API.
- Add shared authentication utilities and a login endpoint that issues HTTP-only cookies for staff sessions.
- Serve the personeel dashboard through a protected API route and require the session cookie on related data endpoints.
- Switch the staff-related API routes to explicit CommonJS exports so they can be executed and tested consistently in local Node environments.

## Testing
- node - <<'NODE' ... # manual harness covering login, dashboard gate, orders summary, and customers APIs


------
https://chatgpt.com/codex/tasks/task_e_68c93dbae9148329854cd8192f1cbb82