### PR TITLE
Fix blog API persistence with Postgres and update client fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Deze website is geoptimaliseerd voor statische hosting op:
 - GitHub Pages
 - Elke andere statische hosting service
 
+## 📝 Blog beheer API
+
+- Serverless endpoint: `/api/blogs`
+- Vereist een PostgreSQL-verbinding via `POSTGRES_URL`, `DATABASE_URL`, `POSTGRES_URL_NON_POOLING` of `POSTGRES_PRISMA_URL`
+- Maakt automatisch de tabel `blog_posts` aan (met kolommen voor titel, slug, content, status, enz.)
+- Ondersteunt `GET`, `POST`, `PUT/PATCH` en `DELETE` voor blogposts
+
 ## 📱 Responsive Design
 
 - Desktop (1200px+)

--- a/api/blogs.js
+++ b/api/blogs.js
@@ -1,0 +1,469 @@
+const { Pool } = require('pg');
+
+const CONNECTION_STRING =
+  process.env.POSTGRES_URL_NON_POOLING ||
+  process.env.POSTGRES_PRISMA_URL ||
+  process.env.POSTGRES_URL ||
+  process.env.DATABASE_URL ||
+  '';
+
+let pool = null;
+let initPromise = null;
+
+function getPool() {
+  if (!CONNECTION_STRING) {
+    const error = new Error(
+      'Database verbinding ontbreekt. Stel POSTGRES_URL of DATABASE_URL in.'
+    );
+    error.statusCode = 500;
+    throw error;
+  }
+
+  if (!pool) {
+    const isLocal =
+      CONNECTION_STRING.includes('localhost') ||
+      CONNECTION_STRING.includes('127.0.0.1');
+
+    pool = new Pool({
+      connectionString: CONNECTION_STRING,
+      ssl: isLocal ? false : { rejectUnauthorized: false },
+      max: 5,
+    });
+
+    pool.on('error', (err) => {
+      console.error('Postgres pool error:', err);
+    });
+  }
+
+  return pool;
+}
+
+async function ensureDatabase() {
+  if (!initPromise) {
+    initPromise = (async () => {
+      const db = getPool();
+      await db.query(`
+        CREATE TABLE IF NOT EXISTS blog_posts (
+          id SERIAL PRIMARY KEY,
+          title TEXT NOT NULL,
+          slug TEXT NOT NULL UNIQUE,
+          meta_title TEXT,
+          meta_description TEXT,
+          content TEXT NOT NULL,
+          featured_image TEXT,
+          status TEXT NOT NULL DEFAULT 'draft',
+          publish_date TEXT,
+          published_date TEXT,
+          read_time INTEGER,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+      `);
+      await db.query(
+        'CREATE INDEX IF NOT EXISTS blog_posts_slug_idx ON blog_posts (slug);'
+      );
+      await db.query(
+        'CREATE INDEX IF NOT EXISTS blog_posts_status_idx ON blog_posts (status);'
+      );
+    })().catch((error) => {
+      initPromise = null;
+      throw error;
+    });
+  }
+
+  return initPromise;
+}
+
+function toCamelCase(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    metaTitle: row.meta_title || '',
+    metaDescription: row.meta_description || '',
+    content: row.content || '',
+    featuredImage: row.featured_image || null,
+    status: row.status || 'draft',
+    publishDate: row.publish_date || null,
+    publishedDate: row.published_date || null,
+    readTime:
+      row.read_time === null || row.read_time === undefined
+        ? null
+        : Number(row.read_time),
+    createdAt: row.created_at ? new Date(row.created_at).toISOString() : null,
+    updatedAt: row.updated_at ? new Date(row.updated_at).toISOString() : null,
+  };
+}
+
+function parseBody(req) {
+  if (!req.body) return {};
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body || '{}');
+    } catch (error) {
+      return {};
+    }
+  }
+  return req.body || {};
+}
+
+function isValidStatus(status) {
+  return ['draft', 'scheduled', 'published', 'offline'].includes(status);
+}
+
+function normalizeReadTime(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const number = Number(value);
+  if (!Number.isFinite(number) || Number.isNaN(number)) return null;
+  return Math.max(0, Math.round(number));
+}
+
+async function handleGet(req, res) {
+  const db = getPool();
+  const { id, slug, status } = req.query || {};
+  const conditions = [];
+  const values = [];
+
+  if (id !== undefined) {
+    const numericId = Number(id);
+    if (!Number.isInteger(numericId) || numericId <= 0) {
+      res.status(400).json({ error: 'Ongeldige ID' });
+      return;
+    }
+    values.push(numericId);
+    conditions.push(`id = $${values.length}`);
+  }
+
+  if (slug) {
+    values.push(String(slug));
+    conditions.push(`slug = $${values.length}`);
+  }
+
+  if (status) {
+    if (!isValidStatus(status)) {
+      res.status(400).json({ error: 'Ongeldige status' });
+      return;
+    }
+    values.push(status);
+    conditions.push(`status = $${values.length}`);
+  }
+
+  let query = `
+    SELECT
+      id,
+      title,
+      slug,
+      meta_title,
+      meta_description,
+      content,
+      featured_image,
+      status,
+      publish_date,
+      published_date,
+      read_time,
+      created_at,
+      updated_at
+    FROM blog_posts
+  `;
+
+  if (conditions.length) {
+    query += ` WHERE ${conditions.join(' AND ')}`;
+  }
+
+  if (id || slug) {
+    query += ' LIMIT 1';
+  } else {
+    query += ' ORDER BY updated_at DESC, created_at DESC';
+  }
+
+  const { rows } = await db.query(query, values);
+
+  if (id || slug) {
+    const row = rows[0];
+    if (!row) {
+      res.status(404).json({ error: 'Blogpost niet gevonden' });
+      return;
+    }
+    res.status(200).json({ success: true, data: toCamelCase(row) });
+    return;
+  }
+
+  res.status(200).json({ success: true, data: rows.map(toCamelCase) });
+}
+
+async function handlePost(req, res) {
+  const db = getPool();
+  const body = parseBody(req);
+  const title = (body.title || '').trim();
+  const slug = (body.slug || '').trim();
+  const rawContent = typeof body.content === 'string' ? body.content : '';
+  const status = body.status && isValidStatus(body.status) ? body.status : 'draft';
+
+  if (!title) {
+    res.status(400).json({ error: 'Titel is verplicht' });
+    return;
+  }
+  if (!slug) {
+    res.status(400).json({ error: 'Slug is verplicht' });
+    return;
+  }
+  if (!rawContent || !rawContent.trim()) {
+    res.status(400).json({ error: 'Inhoud is verplicht' });
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const params = [
+    title,
+    slug,
+    body.metaTitle || '',
+    body.metaDescription || '',
+    rawContent,
+    body.featuredImage || null,
+    status,
+    body.publishDate || null,
+    body.publishedDate || null,
+    normalizeReadTime(body.readTime),
+    now,
+    now,
+  ];
+
+  try {
+    const { rows } = await db.query(
+      `INSERT INTO blog_posts (
+        title,
+        slug,
+        meta_title,
+        meta_description,
+        content,
+        featured_image,
+        status,
+        publish_date,
+        published_date,
+        read_time,
+        created_at,
+        updated_at
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+      RETURNING
+        id,
+        title,
+        slug,
+        meta_title,
+        meta_description,
+        content,
+        featured_image,
+        status,
+        publish_date,
+        published_date,
+        read_time,
+        created_at,
+        updated_at`,
+      params
+    );
+
+    res.status(201).json({ success: true, data: toCamelCase(rows[0]) });
+  } catch (error) {
+    if (error && error.code === '23505') {
+      res.status(409).json({ error: 'Slug is al in gebruik' });
+      return;
+    }
+    console.error('Blog POST error:', error);
+    res.status(500).json({ error: 'Kon blogpost niet opslaan' });
+  }
+}
+
+async function handlePut(req, res) {
+  const db = getPool();
+  const queryId = req.query?.id;
+  const body = parseBody(req);
+  const bodyId = body && body.id ? body.id : null;
+  const targetId = queryId || bodyId;
+
+  const numericId = Number(targetId);
+  if (!Number.isInteger(numericId) || numericId <= 0) {
+    res.status(400).json({ error: 'ID is verplicht voor updates' });
+    return;
+  }
+
+  const updates = [];
+  const values = [];
+
+  if ('title' in body) {
+    const value = (body.title || '').trim();
+    if (!value) {
+      res.status(400).json({ error: 'Titel is verplicht' });
+      return;
+    }
+    values.push(value);
+    updates.push(`title = $${values.length}`);
+  }
+
+  if ('slug' in body) {
+    const value = (body.slug || '').trim();
+    if (!value) {
+      res.status(400).json({ error: 'Slug is verplicht' });
+      return;
+    }
+    values.push(value);
+    updates.push(`slug = $${values.length}`);
+  }
+
+  if ('metaTitle' in body) {
+    values.push(body.metaTitle || '');
+    updates.push(`meta_title = $${values.length}`);
+  }
+
+  if ('metaDescription' in body) {
+    values.push(body.metaDescription || '');
+    updates.push(`meta_description = $${values.length}`);
+  }
+
+  if ('content' in body) {
+    const rawContent = typeof body.content === 'string' ? body.content : '';
+    if (!rawContent.trim()) {
+      res.status(400).json({ error: 'Inhoud is verplicht' });
+      return;
+    }
+    values.push(rawContent);
+    updates.push(`content = $${values.length}`);
+  }
+
+  if ('featuredImage' in body) {
+    values.push(body.featuredImage || null);
+    updates.push(`featured_image = $${values.length}`);
+  }
+
+  if ('status' in body) {
+    if (!isValidStatus(body.status)) {
+      res.status(400).json({ error: 'Ongeldige status' });
+      return;
+    }
+    values.push(body.status);
+    updates.push(`status = $${values.length}`);
+  }
+
+  if ('publishDate' in body) {
+    values.push(body.publishDate || null);
+    updates.push(`publish_date = $${values.length}`);
+  }
+
+  if ('publishedDate' in body) {
+    values.push(body.publishedDate || null);
+    updates.push(`published_date = $${values.length}`);
+  }
+
+  if ('readTime' in body) {
+    values.push(normalizeReadTime(body.readTime));
+    updates.push(`read_time = $${values.length}`);
+  }
+
+  if (!updates.length) {
+    res.status(400).json({ error: 'Geen velden om bij te werken' });
+    return;
+  }
+
+  values.push(new Date().toISOString());
+  updates.push(`updated_at = $${values.length}`);
+
+  values.push(numericId);
+  const idParam = values.length;
+
+  try {
+    const { rows } = await db.query(
+      `UPDATE blog_posts
+        SET ${updates.join(', ')}
+        WHERE id = $${idParam}
+        RETURNING
+          id,
+          title,
+          slug,
+          meta_title,
+          meta_description,
+          content,
+          featured_image,
+          status,
+          publish_date,
+          published_date,
+          read_time,
+          created_at,
+          updated_at`,
+      values
+    );
+
+    if (!rows.length) {
+      res.status(404).json({ error: 'Blogpost niet gevonden' });
+      return;
+    }
+
+    res.status(200).json({ success: true, data: toCamelCase(rows[0]) });
+  } catch (error) {
+    if (error && error.code === '23505') {
+      res.status(409).json({ error: 'Slug is al in gebruik' });
+      return;
+    }
+    console.error('Blog PUT error:', error);
+    res.status(500).json({ error: 'Kon blogpost niet bijwerken' });
+  }
+}
+
+async function handleDelete(req, res) {
+  const db = getPool();
+  const { id } = req.query || {};
+  const numericId = Number(id);
+
+  if (!Number.isInteger(numericId) || numericId <= 0) {
+    res.status(400).json({ error: 'ID is verplicht om te verwijderen' });
+    return;
+  }
+
+  const result = await db.query('DELETE FROM blog_posts WHERE id = $1', [numericId]);
+  if (!result.rowCount) {
+    res.status(404).json({ error: 'Blogpost niet gevonden' });
+    return;
+  }
+
+  res.status(200).json({ success: true });
+}
+
+export default async function handler(req, res) {
+  try {
+    await ensureDatabase();
+  } catch (error) {
+    console.error('Blog API initialisatie fout:', error);
+    const status = error.statusCode || 500;
+    const message = error.statusCode
+      ? error.message
+      : 'Database niet beschikbaar';
+    res.status(status).json({ error: message });
+    return;
+  }
+
+  try {
+    if (req.method === 'GET') {
+      await handleGet(req, res);
+      return;
+    }
+
+    if (req.method === 'POST') {
+      await handlePost(req, res);
+      return;
+    }
+
+    if (req.method === 'PUT' || req.method === 'PATCH') {
+      await handlePut(req, res);
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      await handleDelete(req, res);
+      return;
+    }
+
+    res.setHeader('Allow', 'GET,POST,PUT,PATCH,DELETE');
+    res.status(405).json({ error: 'Methode niet toegestaan' });
+  } catch (error) {
+    console.error('Blog API fout:', error);
+    res.status(500).json({ error: 'Onverwachte serverfout' });
+  }
+}

--- a/blog-editor.html
+++ b/blog-editor.html
@@ -433,12 +433,17 @@
   </div>
 
   <script>
-    (function(){
-      // Check if user has access
-      const key='staff_access_ok';
-      if(localStorage.getItem(key)!=='1'){ 
-        window.location.href='/personeel'; 
-        return; 
+    (async function(){
+      // Check if user has access via cookie set op het personeelsscherm
+      function hasStaffAccess(){
+        return document.cookie.split(';').some(function(part){
+          return part.trim().startsWith('staff_access_ok=');
+        });
+      }
+
+      if(!hasStaffAccess()){
+        window.location.href='/personeel';
+        return;
       }
       
       // Get elements
@@ -461,7 +466,86 @@
       
       // Check if we're editing an existing post
       const urlParams = new URLSearchParams(window.location.search);
-      const editId = urlParams.get('edit');
+      let editId = urlParams.get('edit');
+      let currentPost = null;
+      let blogPostsCache = [];
+      const API_BASE = '/api/blogs';
+
+      async function fetchJson(url, options = {}) {
+        const init = { ...options };
+        init.headers = init.headers ? { ...init.headers } : {};
+        if (init.body && !(init.body instanceof FormData)) {
+          init.headers['Content-Type'] = 'application/json';
+        }
+        const response = await fetch(url, init);
+        const text = await response.text();
+        let data = null;
+        if (text) {
+          try { data = JSON.parse(text); } catch (_) { data = null; }
+        }
+        if (!response.ok) {
+          const message = (data && data.error) || response.statusText || 'Onbekende fout';
+          const error = new Error(message);
+          error.status = response.status;
+          error.details = data;
+          throw error;
+        }
+        return data;
+      }
+
+      async function refreshCache() {
+        try {
+          const res = await fetchJson(API_BASE);
+          blogPostsCache = Array.isArray(res?.data) ? res.data : [];
+        } catch (error) {
+          blogPostsCache = [];
+          console.error('Kon blogposts niet laden', error);
+        }
+        return blogPostsCache;
+      }
+
+      async function fetchPostById(id) {
+        if (!id) return null;
+        const res = await fetchJson(`${API_BASE}?id=${encodeURIComponent(id)}`);
+        return res?.data || null;
+      }
+
+      async function upsertPost(payload) {
+        if (editId) {
+          const res = await fetchJson(`${API_BASE}?id=${encodeURIComponent(editId)}`, {
+            method: 'PUT',
+            body: JSON.stringify(payload)
+          });
+          return res?.data || null;
+        }
+        const res = await fetchJson(API_BASE, {
+          method: 'POST',
+          body: JSON.stringify(payload)
+        });
+        return res?.data || null;
+      }
+
+      async function removePost(id) {
+        if (!id) return;
+        await fetchJson(`${API_BASE}?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+      }
+
+      function updateScheduleButtonLabel(status) {
+        if (!scheduleBtn) return;
+        if (status === 'published') {
+          scheduleBtn.textContent = 'Offline zetten';
+        } else if (status === 'offline') {
+          scheduleBtn.textContent = 'Online zetten';
+        } else {
+          scheduleBtn.textContent = 'Inplannen';
+        }
+      }
+
+      function handleError(prefix, error) {
+        console.error(prefix, error);
+        const message = error && error.message ? error.message : 'Onbekende fout';
+        alert(prefix + ': ' + message);
+      }
 
       // --- Editor UX helpers for "In het kort..." box ---
       function normalizeSummaryHeadersInEditor() {
@@ -520,23 +604,33 @@
         }
       });
       
+      await refreshCache();
+      updateSlugHint();
+
       if (editId) {
-        // Load existing blog post for editing
-        const blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        const post = blogPosts.find(p => p.id == editId);
-        
-        if (post) {
-          blogTitle.value = post.title;
-          blogSlug.value = post.slug;
-          blogMetaTitle.value = post.metaTitle;
-          blogMetaDescription.value = post.metaDescription;
-          blogContent.innerHTML = post.content;
+        try {
+          const post = await fetchPostById(editId);
+          if (!post) {
+            alert('Blogpost niet gevonden');
+            window.location.href = '/personeel-dashboard';
+            return;
+          }
+
+          currentPost = post;
+          blogTitle.value = post.title || '';
+          blogSlug.value = post.slug || '';
+          blogMetaTitle.value = post.metaTitle || '';
+          blogMetaDescription.value = post.metaDescription || '';
+          blogContent.innerHTML = post.content || '';
           if (blogDate) {
             var d = post.publishedDate || post.publishDate || '';
-            if (/^\d{4}-\d{2}-\d{2}$/.test(d)) blogDate.value = d;
+            if (/^\d{4}-\d{2}-\d{2}$/.test(d)) {
+              blogDate.value = d;
+            } else {
+              blogDate.value = '';
+            }
           }
-          
-          // Load existing image if available
+
           if (post.featuredImage) {
             const img = document.createElement('img');
             img.src = post.featuredImage;
@@ -544,21 +638,19 @@
             imagePreview.innerHTML = '';
             imagePreview.appendChild(img);
           }
-          
-          // Update page title and actions for edit mode
+
           document.title = 'Bewerk: ' + post.title + ' - Vitalora';
           document.querySelector('.editor-title').textContent = 'Blog Bewerken';
           document.querySelector('.editor-subtitle').textContent = 'Bewerk je bestaande blog post';
           publishBtn.textContent = 'Bijwerken';
           saveDraftBtn.textContent = 'Als concept opslaan';
-          scheduleBtn.textContent = 'Opnieuw inplannen';
           deleteBtn.style.display = 'inline-block';
-          // Add/offline toggle button inline (reuse schedule button label based on status)
-          if (post.status === 'published') {
-            scheduleBtn.textContent = 'Offline zetten';
-          } else if (post.status === 'offline') {
-            scheduleBtn.textContent = 'Online zetten';
-          }
+          updateScheduleButtonLabel(post.status);
+          updateSlugHint();
+        } catch (error) {
+          handleError('Kon blogpost niet laden', error);
+          window.location.href = '/personeel-dashboard';
+          return;
         }
       }
       
@@ -580,24 +672,32 @@
       }
 
       function isUniqueSlug(slug, ignoreId){
-        try {
-          const posts = JSON.parse(localStorage.getItem('vitalora_blog_posts')||'[]');
-          return !posts.some(p => p.slug === slug && String(p.id) !== String(ignoreId||''));
-        } catch(_) { return true; }
+        if (!slug) return true;
+        return !blogPostsCache.some(function(post){
+          return post.slug === slug && String(post.id) !== String(ignoreId || '');
+        });
+      }
+
+      function updateSlugHint(){
+        if (!slugHint) return;
+        const normalized = normalizeSlug(blogSlug.value);
+        if (blogSlug.value !== normalized) {
+          blogSlug.value = normalized;
+        }
+        const ok = isUniqueSlug(blogSlug.value, editId);
+        slugHint.style.color = ok ? '#64748b' : '#ef4444';
+        slugHint.textContent = ok ? 'Uniek, alleen letters/cijfers/koppelteken' : 'Slug is al in gebruik';
       }
 
       blogTitle.addEventListener('blur', function(){
         if(!blogSlug.value.trim()){
           blogSlug.value = normalizeSlug(blogTitle.value);
         }
+        updateSlugHint();
       });
 
       blogSlug.addEventListener('input', function(){
-        const normalized = normalizeSlug(blogSlug.value);
-        if (blogSlug.value !== normalized) blogSlug.value = normalized;
-        const ok = isUniqueSlug(blogSlug.value, editId);
-        slugHint.style.color = ok ? '#64748b' : '#ef4444';
-        slugHint.textContent = ok ? 'Uniek, alleen letters/cijfers/koppelteken' : 'Slug is al in gebruik';
+        updateSlugHint();
       });
 
       // Toolbar functionality
@@ -707,10 +807,10 @@
         return previewImg ? previewImg.src : null;
       }
 
-      // Save as draft (create or update)
-      saveDraftBtn.addEventListener('click', function() {
+      function buildBasePayload(options = {}) {
+        const requireContent = options && options.requireContent === true;
         const title = blogTitle.value.trim();
-        let slug = blogSlug.value.trim();
+        let slugValue = blogSlug.value.trim();
         const metaTitle = blogMetaTitle.value.trim();
         const metaDescription = blogMetaDescription.value.trim();
         const content = blogContent.innerHTML;
@@ -718,243 +818,234 @@
 
         if (!title) {
           alert('Vul de titel in');
-          return;
+          return null;
         }
 
-        if (!slug) {
-          slug = title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
-          blogSlug.value = slug;
-        }
-
-        let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        if (editId) {
-          const index = blogPosts.findIndex(p => p.id == editId);
-          if (index !== -1) {
-            if (!featuredImage && blogPosts[index].featuredImage) {
-              featuredImage = blogPosts[index].featuredImage;
-            }
-            blogPosts[index] = {
-              ...blogPosts[index],
-              title,
-              slug,
-              metaTitle,
-              metaDescription,
-              content,
-              featuredImage,
-              status: 'draft',
-              updatedAt: new Date().toISOString()
-            };
-          }
+        if (!slugValue) {
+          slugValue = normalizeSlug(title);
         } else {
-          const newPost = {
-            id: Date.now(),
-            title,
-            slug,
-            metaTitle,
-            metaDescription,
-            content,
-            featuredImage,
-            status: 'draft',
-            createdAt: new Date().toISOString(),
-            readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200))
-          };
-          blogPosts.unshift(newPost);
+          slugValue = normalizeSlug(slugValue);
         }
 
-        localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-        alert('Concept succesvol opgeslagen!');
-        window.location.href = '/personeel-dashboard';
+        blogSlug.value = slugValue;
+
+        if (!slugValue) {
+          alert('Slug mag niet leeg zijn');
+          updateSlugHint();
+          return null;
+        }
+
+        if (!isUniqueSlug(slugValue, editId)) {
+          alert('Slug is al in gebruik');
+          updateSlugHint();
+          return null;
+        }
+
+        if (requireContent && !content) {
+          alert('Vul de inhoud in');
+          return null;
+        }
+
+        if (!featuredImage && currentPost && currentPost.featuredImage) {
+          featuredImage = currentPost.featuredImage;
+        }
+
+        const plainWords = content
+          .replace(/<[^>]*>/g, ' ')
+          .split(/\s+/)
+          .filter(Boolean);
+        const readTime = Math.max(3, Math.ceil(plainWords.length / 200));
+
+        updateSlugHint();
+
+        return {
+          title,
+          slug: slugValue,
+          metaTitle,
+          metaDescription,
+          content,
+          featuredImage,
+          readTime
+        };
+      }
+
+      // Save as draft (create or update)
+      saveDraftBtn.addEventListener('click', async function() {
+        const base = buildBasePayload();
+        if (!base) return;
+
+        const payload = {
+          ...base,
+          status: 'draft',
+          publishDate: (blogDate && blogDate.value) ? blogDate.value : (currentPost?.publishDate || null),
+          publishedDate: currentPost?.publishedDate || null
+        };
+
+        try {
+          const saved = await upsertPost(payload);
+          if (!saved) throw new Error('Geen antwoord van de server');
+          currentPost = saved;
+          editId = String(saved.id);
+          deleteBtn.style.display = 'inline-block';
+          updateScheduleButtonLabel(saved.status);
+          await refreshCache();
+          updateSlugHint();
+          alert('Concept succesvol opgeslagen!');
+          window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Opslaan mislukt', error);
+        }
       });
-      
+
       // Schedule or toggle offline/online in edit mode
-      scheduleBtn.addEventListener('click', function() {
-        const title = blogTitle.value.trim();
-        let slug = blogSlug.value.trim();
-        const metaTitle = blogMetaTitle.value.trim();
-        const metaDescription = blogMetaDescription.value.trim();
-        const content = blogContent.innerHTML;
-        let featuredImage = getFeaturedImageFromPreview();
+      scheduleBtn.addEventListener('click', async function() {
+        const base = buildBasePayload({ requireContent: true });
+        if (!base) return;
 
-        if (!title || !content) {
-          alert('Vul titel en inhoud in');
-          return;
-        }
+        const buttonText = this.textContent || '';
 
-        // If in edit mode and button says Offline/Online zetten, toggle
-        if (editId && (this.textContent.includes('Offline') || this.textContent.includes('Online'))) {
-          let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-          const index = blogPosts.findIndex(p => p.id == editId);
-          if (index !== -1) {
-            const nextStatus = this.textContent.includes('Offline') ? 'offline' : 'published';
-            blogPosts[index].status = nextStatus;
-            localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
+        if (editId && (buttonText.includes('Offline') || buttonText.includes('Online'))) {
+          const nextStatus = buttonText.includes('Offline') ? 'offline' : 'published';
+          const payload = {
+            ...base,
+            status: nextStatus,
+            publishDate: currentPost?.publishDate || null,
+            publishedDate: currentPost?.publishedDate || null
+          };
+          try {
+            const saved = await upsertPost(payload);
+            if (!saved) throw new Error('Geen antwoord van de server');
+            currentPost = saved;
+            editId = String(saved.id);
+            updateScheduleButtonLabel(saved.status);
+            await refreshCache();
+            updateSlugHint();
             alert(nextStatus === 'offline' ? 'Blog offline gezet' : 'Blog online gezet');
             window.location.href = '/personeel-dashboard';
-            return;
+          } catch (error) {
+            handleError('Status bijwerken mislukt', error);
           }
+          return;
         }
 
         const scheduleDate = (blogDate && blogDate.value) ? blogDate.value : prompt('Voer datum (YYYY-MM-DD):');
         if (!scheduleDate) return;
 
-        if (!slug) {
-          slug = title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
-          blogSlug.value = slug;
-        }
+        const payload = {
+          ...base,
+          status: 'scheduled',
+          publishDate: scheduleDate,
+          publishedDate: null
+        };
 
-        let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        if (editId) {
-          const index = blogPosts.findIndex(p => p.id == editId);
-          if (index !== -1) {
-            if (!featuredImage && blogPosts[index].featuredImage) {
-              featuredImage = blogPosts[index].featuredImage;
-            }
-            blogPosts[index] = {
-              ...blogPosts[index],
-              title,
-              slug,
-              metaTitle,
-              metaDescription,
-              content,
-              featuredImage,
-              status: 'scheduled',
-              publishDate: scheduleDate,
-              updatedAt: new Date().toISOString()
-            };
-          }
-        } else {
-          const newPost = {
-            id: Date.now(),
-            title,
-            slug,
-            metaTitle,
-            metaDescription,
-            content,
-            featuredImage,
-            status: 'scheduled',
-            publishDate: scheduleDate,
-            createdAt: new Date().toISOString(),
-            readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200))
-          };
-          blogPosts.unshift(newPost);
+        try {
+          const saved = await upsertPost(payload);
+          if (!saved) throw new Error('Geen antwoord van de server');
+          currentPost = saved;
+          editId = String(saved.id);
+          deleteBtn.style.display = 'inline-block';
+          updateScheduleButtonLabel(saved.status);
+          await refreshCache();
+          updateSlugHint();
+          alert('Blog succesvol ingepland!');
+          window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Inplannen mislukt', error);
         }
-
-        localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-        alert('Blog succesvol ingepland!');
-        window.location.href = '/personeel-dashboard';
       });
-      
+
       // Publish blog
-      publishBtn.addEventListener('click', function() {
-        const title = blogTitle.value.trim();
-        const slug = blogSlug.value.trim();
-        const metaTitle = blogMetaTitle.value.trim();
-        const metaDescription = blogMetaDescription.value.trim();
-        const content = blogContent.innerHTML;
-        let featuredImage = getFeaturedImageFromPreview();
-        
-        if (!title || !content) {
-          alert('Vul titel en inhoud in');
+      publishBtn.addEventListener('click', async function() {
+        const base = buildBasePayload({ requireContent: true });
+        if (!base) return;
+
+        if (!confirm('Weet je zeker dat je deze blog post wilt publiceren?')) {
           return;
         }
-        
-        if (confirm('Weet je zeker dat je deze blog post wilt publiceren?')) {
-          // Get existing blog posts
-          let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-          
-          if (editId) {
-            // Update existing blog post
-            const postIndex = blogPosts.findIndex(p => p.id == editId);
-            if (postIndex !== -1) {
-              const existing = blogPosts[postIndex];
-              if (!featuredImage && existing.featuredImage) {
-                featuredImage = existing.featuredImage;
-              }
-              blogPosts[postIndex] = {
-                ...existing,
-                title,
-                slug: slug, // Always use the new slug value
-                metaTitle,
-                metaDescription,
-                content,
-                featuredImage,
-                status: 'published',
-                publishedDate: (blogDate && blogDate.value) ? blogDate.value : (existing.publishedDate || new Date().toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' })),
-                readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200)),
-                updatedAt: new Date().toISOString()
-              };
-              alert('Blog succesvol bijgewerkt!');
-            }
+
+        const wasExisting = Boolean(editId);
+        let publishedDate = (blogDate && blogDate.value) ? blogDate.value : null;
+        if (!publishedDate) {
+          if (currentPost && currentPost.publishedDate) {
+            publishedDate = currentPost.publishedDate;
           } else {
-            // Create new blog post
-            const blogPost = {
-              id: Date.now(),
-              title: title,
-              slug: slug,
-              metaTitle: metaTitle,
-              metaDescription: metaDescription,
-              content: content,
-              featuredImage: featuredImage,
-              status: 'published',
-              publishedDate: (blogDate && blogDate.value) ? blogDate.value : new Date().toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' }),
-              readTime: Math.max(3, Math.ceil(content.replace(/<[^>]*>/g, '').split(' ').length / 200))
-            };
-            
-            // Add new blog post
-            blogPosts.unshift(blogPost);
-            alert('Blog succesvol gepubliceerd!');
+            publishedDate = new Date().toLocaleDateString('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' });
           }
-          
-          // Save back to localStorage
-          localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-          
-          console.log('Publishing blog:', blogPosts[editId ? blogPosts.findIndex(p => p.id == editId) : 0]);
+        }
+
+        const payload = {
+          ...base,
+          status: 'published',
+          publishDate: null,
+          publishedDate
+        };
+
+        try {
+          const saved = await upsertPost(payload);
+          if (!saved) throw new Error('Geen antwoord van de server');
+          currentPost = saved;
+          editId = String(saved.id);
+          deleteBtn.style.display = 'inline-block';
+          updateScheduleButtonLabel(saved.status);
+          await refreshCache();
+          updateSlugHint();
+          alert(wasExisting ? 'Blog succesvol bijgewerkt!' : 'Blog succesvol gepubliceerd!');
           window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Publiceren mislukt', error);
         }
       });
 
       // Delete blog
-      deleteBtn.addEventListener('click', function(){
+      deleteBtn.addEventListener('click', async function(){
         if(!editId){ return; }
         if(!confirm('Weet je zeker dat je deze blog wilt verwijderen?')) return;
-        let blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        blogPosts = blogPosts.filter(p => p.id != editId);
-        localStorage.setItem('vitalora_blog_posts', JSON.stringify(blogPosts));
-        alert('Blog verwijderd');
-        window.location.href = '/personeel-dashboard';
+        try {
+          await removePost(editId);
+          alert('Blog verwijderd');
+          window.location.href = '/personeel-dashboard';
+        } catch (error) {
+          handleError('Verwijderen mislukt', error);
+        }
       });
-      
+
       // Preview opens post.html with current slug in new tab
       const previewBtn = document.getElementById('preview-blog');
       if (previewBtn) {
-        previewBtn.addEventListener('click', function(){
+        previewBtn.addEventListener('click', async function(){
           const slug = normalizeSlug(blogSlug.value || blogTitle.value);
           if(!slug){ alert('Vul eerst titel of slug in'); return; }
-          // ensure current changes are reflected for preview: save draft temporarily in storage
+          blogSlug.value = slug;
+
+          const base = buildBasePayload();
+          if (!base) return;
+
+          const payload = {
+            ...base,
+            slug,
+            status: currentPost?.status || 'draft',
+            publishDate: (blogDate && blogDate.value) ? blogDate.value : (currentPost?.publishDate || null),
+            publishedDate: currentPost?.publishedDate || null
+          };
+
           try {
-            let posts = JSON.parse(localStorage.getItem('vitalora_blog_posts')||'[]');
-            const idx = editId ? posts.findIndex(p=>String(p.id)===String(editId)) : -1;
-            const doc = {
-              id: editId || Date.now(),
-              title: blogTitle.value.trim() || slug,
-              slug: slug,
-              metaTitle: blogMetaTitle.value.trim(),
-              metaDescription: blogMetaDescription.value.trim(),
-              content: blogContent.innerHTML,
-              featuredImage: (function(){
-                const img= document.getElementById('image-preview')?.querySelector('img');
-                return img? img.src : (idx>=0 && posts[idx] && posts[idx].featuredImage) ? posts[idx].featuredImage : null;
-              })(),
-              status: (idx>=0 && posts[idx].status) || 'draft',
-              updatedAt: new Date().toISOString()
-            };
-            if (idx>=0) { posts[idx]= { ...posts[idx], ...doc }; } else { posts.unshift(doc); }
-            localStorage.setItem('vitalora_blog_posts', JSON.stringify(posts));
-          } catch(_){}
+            const saved = await upsertPost(payload);
+            if (!saved) throw new Error('Geen antwoord van de server');
+            currentPost = saved;
+            editId = String(saved.id);
+            deleteBtn.style.display = 'inline-block';
+            updateScheduleButtonLabel(saved.status);
+            await refreshCache();
+            updateSlugHint();
+          } catch (error) {
+            handleError('Opslaan voor preview mislukt', error);
+            return;
+          }
+
           window.open('/post.html?slug=' + encodeURIComponent(slug), '_blank');
         });
       }
-      
+
     })();
   </script>
 </body>

--- a/blog.html
+++ b/blog.html
@@ -238,94 +238,152 @@
             </div>
         </footer>
 
-                <script>
-        console.log('=== BLOG PAGE SCRIPT START (blog.html) ===');
-        var postsContainer = document.getElementById('posts');
-        console.log('Posts container found:', postsContainer);
-        if (postsContainer) {
-            var publishedPosts = [];
+        <script>
+        (function(){
+          const postsContainer = document.getElementById('posts');
+          if (!postsContainer) return;
+
+          const API_BASE = '/api/blogs';
+
+          function formatReadTime(value) {
+            const number = Number(value);
+            const minutes = Number.isFinite(number) && !Number.isNaN(number) && number > 0
+              ? Math.round(number)
+              : 5;
+            return minutes + ' min leestijd';
+          }
+
+          function slugifyFallback(title) {
+            return (title || 'artikel')
+              .toLowerCase()
+              .replace(/[^a-z0-9\s-]/g, '')
+              .replace(/\s+/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, '');
+          }
+
+          function buildFallbackImage(title) {
+            const keywords = (title || '').toLowerCase().split(' ').slice(0, 2).join(',');
+            return 'https://source.unsplash.com/800x450/?' + encodeURIComponent(keywords + ',health,wellness');
+          }
+
+          function createCard(post) {
+            const card = document.createElement('div');
+            card.className = 'post-card';
+
+            const slug = post.slug || '';
+            const fallbackSlug = slugifyFallback(post.title || '');
+            const targetSlug = slug || fallbackSlug;
+            const destination = slug
+              ? '/' + encodeURIComponent(targetSlug)
+              : '/post.html?slug=' + encodeURIComponent(targetSlug);
+
+            card.addEventListener('click', function(){
+              window.location.href = destination;
+            });
+
+            const publishedDate = post.publishedDate || post.publishDate || '';
+            const readTime = formatReadTime(post.readTime);
+            const imageSrc = post.featuredImage || buildFallbackImage(post.title);
+            const fallbackSrc = post.featuredImage || 'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=800&q=60';
+
+            card.innerHTML =
+              '<div class="post-cover"><img src="' + imageSrc + '" alt="" onerror="this.src=\'' + fallbackSrc + '\'" /></div>' +
+              '<div class="post-body">' +
+                '<div class="post-title">' + (post.title || 'Artikel') + '</div>' +
+                '<div class="post-meta">' +
+                  '<div class="post-date">' + (publishedDate || '') + '</div>' +
+                  '<div class="post-read-time">' + readTime + '</div>' +
+                '</div>' +
+              '</div>';
+
+            return card;
+          }
+
+          function renderPosts(list) {
+            postsContainer.innerHTML = '';
+            list.forEach(function(post){
+              postsContainer.appendChild(createCard(post));
+            });
+          }
+
+          function loadFromLocalStorage() {
             try {
-                var stored = localStorage.getItem('vitalora_blog_posts');
-                console.log('localStorage data:', stored);
-                if (stored) {
-                    var allPosts = JSON.parse(stored);
-                    for (var i = 0; i < allPosts.length; i++) {
-                        var post = allPosts[i];
-                        if ((post.status || 'published') === 'published') {
-                            publishedPosts.push(post);
-                        }
-                    }
-                }
-            } catch (e) {
-                console.log('Error loading posts:', e);
+              const stored = localStorage.getItem('vitalora_blog_posts');
+              if (!stored) return [];
+              const parsed = JSON.parse(stored);
+              if (!Array.isArray(parsed)) return [];
+              return parsed.filter(function(post){
+                return (post && (post.status || 'published') === 'published');
+              });
+            } catch (error) {
+              console.warn('Kon localStorage niet lezen:', error);
+              return [];
             }
-            console.log('Total published posts:', publishedPosts.length);
-            for (var j = 0; j < publishedPosts.length; j++) {
-                var post = publishedPosts[j];
-                var card = document.createElement('div');
-                card.className = 'post-card';
-                card.onclick = (function(id, slug){ return function(){
-                  const url = slug ? ('/' + encodeURIComponent(slug)) : ('/post.html?slug=' + (post.title || 'artikel-' + id).toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, ''));
-                  window.location.href = url;
-                }; })(post.id, post.slug);
-                // Use featured image if available, otherwise fallback to Unsplash
-                var imgSrc;
-                if (post.featuredImage) {
-                    imgSrc = post.featuredImage;
-                } else {
-                    var keywords = (post.title || '').toLowerCase().split(' ').slice(0, 2).join(',');
-                    var fallbackImg = 'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=800&q=60';
-                    imgSrc = 'https://source.unsplash.com/800x450/?' + encodeURIComponent(keywords + ',health,wellness');
-                }
-                card.innerHTML = '<div class="post-cover"><img src="' + imgSrc + '" alt="" onerror="this.src=\'' + (post.featuredImage ? post.featuredImage : 'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=800&q=60') + '\'" /></div>' +
-                                 '<div class="post-body">' +
-                                   '<div class="post-title">' + (post.title || 'Artikel') + '</div>' +
-                                   '<div class="post-meta"><div class="post-date">' + (post.publishedDate || '') + '</div><div class="post-read-time">' + (post.readTime || 5) + ' min leestijd</div></div>' +
-                                 '</div>';
-                postsContainer.appendChild(card);
+          }
+
+          async function fetchPublishedFromApi() {
+            try {
+              const res = await fetch(API_BASE + '?status=published', { cache: 'no-store' });
+              if (!res.ok) {
+                if (res.status === 404) return [];
+                throw new Error('API fout: ' + res.status);
+              }
+              const data = await res.json();
+              if (Array.isArray(data?.data)) {
+                return data.data.filter(function(post){
+                  return (post.status || 'published') === 'published';
+                });
+              }
+              return [];
+            } catch (error) {
+              console.warn('Kon blogposts niet uit API laden:', error);
+              return null;
             }
-            if (publishedPosts.length === 0) {
-                console.log('No posts found in localStorage. Trying fallback feed /blog-feed.json');
-                fetch('/blog-feed.json?v=' + Date.now())
-                    .then(function(res){ if (!res.ok) throw new Error('HTTP ' + res.status); return res.json(); })
-                    .then(function(data){
-                        if (Array.isArray(data) && data.length) {
-                            postsContainer.innerHTML = '';
-                            for (var j2 = 0; j2 < data.length; j2++) {
-                                var post2 = data[j2];
-                                var card2 = document.createElement('div');
-                                card2.className = 'post-card';
-                                card2.onclick = (function(id, slug){ return function(){
-                                  const url = slug ? ('/' + encodeURIComponent(slug)) : ('/post.html?slug=' + (post2.title || 'artikel-' + id).toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, ''));
-                                  window.location.href = url;
-                                }; })(post2.id, post2.slug);
-                                // Use featured image if available, otherwise fallback to Unsplash
-                                var imgSrc2;
-                                if (post2.featuredImage) {
-                                    imgSrc2 = post2.featuredImage;
-                                } else {
-                                    var keywords2 = (post2.title || '').toLowerCase().split(' ').slice(0, 2).join(',');
-                                    var fallbackImg2 = 'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=800&q=60';
-                                    imgSrc2 = 'https://source.unsplash.com/800x450/?' + encodeURIComponent(keywords2 + ',health,wellness');
-                                }
-                                card2.innerHTML = '<div class="post-cover"><img src="' + imgSrc2 + '" alt="" onerror="this.src=\'' + (post2.featuredImage ? post2.featuredImage : 'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=800&q=60') + '\'" /></div>' +
-                                                 '<div class="post-body">' +
-                                                   '<div class="post-title">' + (post2.title || 'Artikel') + '</div>' +
-                                                   '<div class="post-meta"><div class="post-date">' + (post2.publishedDate || '') + '</div><div class="post-read-time">' + (post2.readTime || 5) + ' min leestijd</div></div>' +
-                                                 '</div>';
-                                postsContainer.appendChild(card2);
-                            }
-                            return;
-                        }
-                        postsContainer.innerHTML = '<div style="text-align: center; padding: 40px; color: #6b7280;"><p>Geen artikelen gevonden.</p><p>Kom later terug.</p></div>';
-                    })
-                    .catch(function(err){
-                        console.log('Fallback feed failed:', err);
-                        postsContainer.innerHTML = '<div style="text-align: center; padding: 40px; color: #6b7280;"><p>Geen artikelen gevonden.</p><p>Kom later terug.</p></div>';
-                    });
+          }
+
+          async function fetchFallbackFeed() {
+            try {
+              const res = await fetch('/blog-feed.json?v=' + Date.now());
+              if (!res.ok) throw new Error('HTTP ' + res.status);
+              const data = await res.json();
+              if (Array.isArray(data)) {
+                return data.filter(function(post){
+                  return (post && (post.status || 'published') === 'published');
+                });
+              }
+            } catch (error) {
+              console.warn('Fallback feed laden mislukt:', error);
             }
-        }
-        console.log('=== BLOG PAGE SCRIPT END (blog.html) ===');
+            return [];
+          }
+
+          async function loadPosts() {
+            postsContainer.innerHTML = '<div style="text-align: center; padding: 40px; color: #6b7280;">Laden...</div>';
+
+            let posts = await fetchPublishedFromApi();
+            if (Array.isArray(posts) && posts.length) {
+              renderPosts(posts);
+              return;
+            }
+
+            const cached = loadFromLocalStorage();
+            if (cached.length) {
+              renderPosts(cached);
+              return;
+            }
+
+            posts = await fetchFallbackFeed();
+            if (Array.isArray(posts) && posts.length) {
+              renderPosts(posts);
+              return;
+            }
+
+            postsContainer.innerHTML = '<div style="text-align: center; padding: 40px; color: #6b7280;"><p>Geen artikelen gevonden.</p><p>Kom later terug.</p></div>';
+          }
+
+          loadPosts();
+        })();
         </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "@sendgrid/mail": "^8.1.0",
-    "nodemailer": "^6.9.13"
+    "nodemailer": "^6.9.13",
+    "pg": "^8.11.5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/personeel-dashboard.html
+++ b/personeel-dashboard.html
@@ -114,8 +114,37 @@
 
   <script>
     (function(){
-      const key='staff_access_ok';
-      if(localStorage.getItem(key)!=='1'){ window.location.href='/personeel'; return; }
+      function hasStaffAccess(){
+        return document.cookie.split(';').some(function(part){
+          return part.trim().startsWith('staff_access_ok=');
+        });
+      }
+
+      if(!hasStaffAccess()){ window.location.href='/personeel'; return; }
+
+      const API_BASE = '/api/blogs';
+
+      async function fetchJson(url, options = {}){
+        const init = { ...options };
+        init.headers = init.headers ? { ...init.headers } : {};
+        if (init.body && !(init.body instanceof FormData)) {
+          init.headers['Content-Type'] = 'application/json';
+        }
+        const response = await fetch(url, init);
+        const text = await response.text();
+        let data = null;
+        if (text) {
+          try { data = JSON.parse(text); } catch (_) { data = null; }
+        }
+        if (!response.ok) {
+          const message = (data && data.error) || response.statusText || 'Onbekende fout';
+          const error = new Error(message);
+          error.status = response.status;
+          error.details = data;
+          throw error;
+        }
+        return data;
+      }
       // Revenue fetch
       async function loadRevenue(){
         try{
@@ -132,94 +161,107 @@
       loadRevenue();
       setInterval(loadRevenue, 60000);
       
+
+      function escapeHtml(value){
+        return String(value || '').replace(/[&<>"']/g, function(char){
+          return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[char];
+        });
+      }
+
       // Load and display blog posts in the table
-      function loadBlogPosts() {
-        const blogPosts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
+      async function loadBlogPosts() {
         const tableBody = document.getElementById('blog-posts-table');
-        
+
         if (!tableBody) return;
-        
-        // Clear existing rows
-        tableBody.innerHTML = '';
-        
-        if (blogPosts.length === 0) {
-          tableBody.innerHTML = '<tr><td colspan="2" style="text-align: center; color: #6b7280; padding: 20px;">Geen blog posts gevonden</td></tr>';
-          return;
-        }
-        
-        // Add each blog post as a table row
-        blogPosts.forEach(function(post) {
-          const row = document.createElement('tr');
-          row.style.cursor = 'pointer';
-          row.onclick = function() {
-            // Open blog editor for editing
-            window.open('/blog-editor.html?edit=' + post.id, '_blank');
-          };
-          
-          const statusMap = {
-            published: {label:'Gepubliceerd', bg:'#10b981'},
-            draft: {label:'Concept', bg:'#6b7280'},
-            scheduled: {label:'Ingepland', bg:'#f59e0b'},
-            offline: {label:'Offline', bg:'#ef4444'}
-          };
-          const meta = statusMap[post.status] || statusMap.published;
-          row.innerHTML = `
-            <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; color: #333333;">${post.title}</td>
+
+        tableBody.innerHTML = '<tr><td colspan="3" style="text-align: center; color: #6b7280; padding: 20px;">Laden...</td></tr>';
+
+        try {
+          const res = await fetchJson(API_BASE);
+          const blogPosts = Array.isArray(res?.data) ? res.data : [];
+
+          tableBody.innerHTML = '';
+
+          if (!blogPosts.length) {
+            tableBody.innerHTML = '<tr><td colspan="3" style="text-align: center; color: #6b7280; padding: 20px;">Geen blog posts gevonden</td></tr>';
+            return;
+          }
+
+          blogPosts.forEach(function(post) {
+            const row = document.createElement('tr');
+            row.style.cursor = 'pointer';
+            row.onclick = function() {
+              window.open('/blog-editor.html?edit=' + encodeURIComponent(post.id), '_blank');
+            };
+
+            const statusMap = {
+              published: {label:'Gepubliceerd', bg:'#10b981'},
+              draft: {label:'Concept', bg:'#6b7280'},
+              scheduled: {label:'Ingepland', bg:'#f59e0b'},
+              offline: {label:'Offline', bg:'#ef4444'}
+            };
+            const meta = statusMap[post.status] || statusMap.published;
+            const safeTitle = escapeHtml(post.title || 'Zonder titel');
+
+            row.innerHTML = `
+            <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; color: #333333;">${safeTitle}</td>
             <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; color: #333333;">
               <span style="background: ${meta.bg}; color: white; padding: 4px 8px; border-radius: 12px; font-size: 12px; font-weight: 600;">
                 ${meta.label}
               </span>
             </td>
             <td style="padding: 12px 10px; border-bottom: 1px solid #eef2f7; text-align:right; white-space:nowrap;">
-              <button class="view-post" data-id="${post.id}" aria-label="Bekijken" title="Bekijken" style="background:transparent;border:0;color:#3A9AEA;cursor:pointer;padding:6px;border-radius:6px;margin-right:6px;">
+              <button class="view-post" aria-label="Bekijken" title="Bekijken" style="background:transparent;border:0;color:#3A9AEA;cursor:pointer;padding:6px;border-radius:6px;margin-right:6px;">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                   <path d="M12 5c-7 0-11 7-11 7s4 7 11 7 11-7 11-7-4-7-11-7zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 .001 6.001A3 3 0 0 0 12 9z"/>
                 </svg>
               </button>
-              <button class="delete-post" data-id="${post.id}" aria-label="Verwijderen" title="Verwijderen" style="background:transparent;border:0;color:#ef4444;cursor:pointer;padding:6px;border-radius:6px;">
+              <button class="delete-post" aria-label="Verwijderen" title="Verwijderen" style="background:transparent;border:0;color:#ef4444;cursor:pointer;padding:6px;border-radius:6px;">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                   <path d="M9 3h6a1 1 0 0 1 1 1v1h5v2h-1v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7H3V5h5V4a1 1 0 0 1 1-1zm1 2v0h4V5h-4zM6 7v12h12V7H6zm4 2h2v8h-2V9zm-4 0h2v8H6V9zm10 0h-2v8h2V9z"/>
                 </svg>
               </button>
             </td>
           `;
-          // Hook delete button
-          const del = row.querySelector('.delete-post');
-          if (del) {
-            del.addEventListener('click', function(ev){
-              ev.stopPropagation();
-              const id = this.getAttribute('data-id');
-              if (!id) return;
-              if (!confirm('Weet je zeker dat je deze blog wilt verwijderen?')) return;
-              let list = [];
-              try { list = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]'); } catch(_) {}
-              list = list.filter(function(p){ return String(p.id) !== String(id); });
-              localStorage.setItem('vitalora_blog_posts', JSON.stringify(list));
-              loadBlogPosts();
-            });
-          }
-          
-          // Hook view button
-          const viewBtn = row.querySelector('.view-post');
-          if (viewBtn) {
-            viewBtn.addEventListener('click', function(ev){
-              ev.stopPropagation();
-              const id = this.getAttribute('data-id');
-              let list = [];
-              try { list = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]'); } catch(_) {}
-              const post = list.find(function(p){ return String(p.id) === String(id); });
-              if (!post) return;
-              const slug = post.slug || '';
-              const status = post.status || 'published';
-              const url = status === 'published' ? ('/' + encodeURIComponent(slug)) : ('/post.html?slug=' + encodeURIComponent(slug));
-              window.open(url, '_blank');
-            });
-          }
-          
-          tableBody.appendChild(row);
-        });
+
+            const del = row.querySelector('.delete-post');
+            if (del) {
+              del.addEventListener('click', async function(ev){
+                ev.stopPropagation();
+                if (!confirm('Weet je zeker dat je deze blog wilt verwijderen?')) return;
+                try {
+                  await fetchJson(`${API_BASE}?id=${encodeURIComponent(post.id)}`, { method: 'DELETE' });
+                  await loadBlogPosts();
+                } catch (error) {
+                  alert('Verwijderen mislukt: ' + (error && error.message ? error.message : 'Onbekende fout'));
+                }
+              });
+            }
+
+            const viewBtn = row.querySelector('.view-post');
+            if (viewBtn) {
+              viewBtn.addEventListener('click', function(ev){
+                ev.stopPropagation();
+                const slug = post.slug || '';
+                if (!slug) {
+                  window.open('/blog-editor.html?edit=' + encodeURIComponent(post.id), '_blank');
+                  return;
+                }
+                const status = post.status || 'published';
+                const url = status === 'published' ? ('/' + encodeURIComponent(slug)) : ('/post.html?slug=' + encodeURIComponent(slug));
+                window.open(url, '_blank');
+              });
+            }
+
+            tableBody.appendChild(row);
+          });
+        } catch (error) {
+          const message = error && error.message ? error.message : 'Onbekende fout';
+          tableBody.innerHTML = '<tr><td colspan="3" style="text-align: center; color: #ef4444; padding: 20px;">Fout bij laden: ' + escapeHtml(message) + '</td></tr>';
+        }
       }
-      
+
+// No extra actions here; only listing and create button per verzoek
       // No extra actions here; only listing and create button per verzoek
       
       // Load blog posts when page loads

--- a/personeel.html
+++ b/personeel.html
@@ -99,7 +99,7 @@
       enterButton.addEventListener('click', function(){
         const code = Array.from(pinInputs).map(input => input.value).join('');
         if(code === '248911') {
-          localStorage.setItem('staff_access_ok','1');
+          document.cookie = 'staff_access_ok=1; path=/; max-age=86400';
           window.location.href = '/personeel-dashboard';
         } else {
           errorDiv.textContent = 'Ongeldige code.';

--- a/post.html
+++ b/post.html
@@ -62,52 +62,60 @@
   </main>
 
   <script>
-    console.log('=== POST TEMPLATE SCRIPT START ===');
-    
     (async function(){
-      const params = new URLSearchParams(location.search);
-      // Haal slug uit querystring of uit de path (pretty URL: /:slug)
-      let slug = params.get('slug');
-      console.log('Slug from params:', slug);
-      
-      if (!slug) {
-        const path = (location.pathname || '/').replace(/\/$/, '');
-        // Neem laatste segment tenzij het leeg of 'post.html' is
-        const segments = path.split('/').filter(Boolean);
-        const last = segments[segments.length - 1] || '';
-        slug = (last && last !== 'post.html') ? last : '';
-        console.log('Slug from path:', slug);
+      const API_BASE = '/api/blogs';
+
+      function hasStaffAccess(){
+        return document.cookie.split(';').some(function(part){
+          return part.trim().startsWith('staff_access_ok=');
+        });
       }
 
-      const titleEl = document.getElementById('post-title');
-      const metaEl = document.getElementById('post-meta');
-      const contentEl = document.getElementById('post-content');
-
-      if (!slug) {
-        titleEl.textContent = 'Blog post niet gevonden';
-        contentEl.innerHTML = '<p>Geen slug opgegeven.</p>';
-        return;
+      function slugToTitle(value){
+        return (value || '')
+          .replace(/-/g, ' ')
+          .replace(/\b\w/g, function(letter){ return letter.toUpperCase(); });
       }
 
-      // Toon basis info
-      titleEl.textContent = slug.replace(/-/g,' ').replace(/\b\w/g, c => c.toUpperCase());
-      if (metaEl) { metaEl.textContent = '/' + slug; }
-
-      // 1) Probeer uit localStorage (van jouw CRM)
-      let post = null;
-      try {
-        const posts = JSON.parse(localStorage.getItem('vitalora_blog_posts') || '[]');
-        console.log('Posts from localStorage:', posts);
-        post = posts.find(p => (p.slug === slug));
-        console.log('Found post:', post);
-      } catch (e) {
-        console.log('Error loading from localStorage:', e);
+      function formatReadTime(value){
+        const number = Number(value);
+        const minutes = Number.isFinite(number) && !Number.isNaN(number) && number > 0
+          ? Math.round(number)
+          : 5;
+        return minutes;
       }
 
-      // 2) Fallback: probeer statische HTML te halen en te parsen
-      async function fetchStatic(sl){
+      async function fetchPostFromApi(slug){
         try {
-          const res = await fetch('/' + encodeURIComponent(sl) + '.html', { credentials: 'same-origin' });
+          const res = await fetch(API_BASE + '?slug=' + encodeURIComponent(slug), { cache: 'no-store' });
+          if (res.status === 404) return null;
+          if (!res.ok) throw new Error('API fout: ' + res.status);
+          const data = await res.json();
+          return data?.data || null;
+        } catch (error) {
+          console.warn('Kon blogpost niet uit API laden:', error);
+          return null;
+        }
+      }
+
+      function loadFromLocalStorage(slug){
+        try {
+          const stored = localStorage.getItem('vitalora_blog_posts');
+          if (!stored) return null;
+          const parsed = JSON.parse(stored);
+          if (!Array.isArray(parsed)) return null;
+          return parsed.find(function(post){
+            return post && post.slug === slug;
+          }) || null;
+        } catch (error) {
+          console.warn('Kon localStorage niet lezen:', error);
+          return null;
+        }
+      }
+
+      async function fetchStatic(slug){
+        try {
+          const res = await fetch('/' + encodeURIComponent(slug) + '.html', { credentials: 'same-origin' });
           if (!res.ok) return null;
           const html = await res.text();
           const parser = new DOMParser();
@@ -115,96 +123,148 @@
           const h1 = doc.querySelector('.blog-title, h1');
           const content = doc.querySelector('.blog-content, article, main');
           const dateEl = doc.querySelector('.blog-date');
-          const parsed = {
-            title: h1 ? h1.textContent.trim() : slug.replace(/-/g,' '),
+          return {
+            title: h1 ? h1.textContent.trim() : slugToTitle(slug),
             content: content ? content.innerHTML : '<p>Geen inhoud gevonden.</p>',
             publishedDate: dateEl ? dateEl.textContent.trim() : ''
           };
-          return parsed;
-        } catch (e) {
+        } catch (error) {
+          console.warn('Kon statisch fallback bestand niet laden:', error);
           return null;
         }
       }
 
+      function cachePost(post){
+        try {
+          const key = 'vitalora_blog_posts';
+          const stored = localStorage.getItem(key);
+          const parsed = stored ? JSON.parse(stored) : [];
+          const list = Array.isArray(parsed) ? parsed : [];
+          const others = list.filter(function(item){
+            if (!item) return false;
+            if (post.id && item.id) return Number(item.id) !== Number(post.id);
+            return item.slug !== post.slug;
+          });
+          others.push(post);
+          localStorage.setItem(key, JSON.stringify(others));
+        } catch (error) {
+          console.warn('Kon post niet cachen:', error);
+        }
+      }
+
+      function normalizeSummaryHeaders(){
+        try {
+          var headers = document.querySelectorAll('.summary-header');
+          headers.forEach(function(h){
+            var icon = h.querySelector('.icon');
+            h.innerHTML = '';
+            var iconEl = document.createElement('div');
+            iconEl.className = 'icon';
+            iconEl.textContent = '📋';
+            h.appendChild(iconEl);
+            h.appendChild(document.createTextNode(' In het kort...'));
+          });
+        } catch(_) {}
+      }
+
+      const params = new URLSearchParams(location.search);
+      let slug = params.get('slug');
+      if (!slug) {
+        const path = (location.pathname || '/').replace(/\/$/, '');
+        const segments = path.split('/').filter(Boolean);
+        const last = segments[segments.length - 1] || '';
+        slug = (last && last !== 'post.html') ? last : '';
+      }
+
+      const titleEl = document.getElementById('post-title');
+      const contentEl = document.getElementById('post-content');
+      const dateEl = document.getElementById('post-date');
+      const readTimeEl = document.getElementById('post-read-time');
+      const featuredWrap = document.getElementById('featured-image');
+
+      if (!slug) {
+        titleEl.textContent = 'Blog post niet gevonden';
+        contentEl.innerHTML = '<p>Geen slug opgegeven.</p>';
+        dateEl.textContent = '-';
+        readTimeEl.textContent = '-';
+        return;
+      }
+
+      titleEl.textContent = slugToTitle(slug);
+
+      let post = await fetchPostFromApi(slug);
       if (!post) {
-        console.log('No post found in localStorage, trying static fallback...');
+        post = loadFromLocalStorage(slug);
+      }
+      if (!post) {
         post = await fetchStatic(slug);
-        console.log('Static fallback result:', post);
       }
 
       if (!post) {
-        console.log('No post found anywhere, showing empty state');
-        // Niets gevonden in storage en geen statische fallback: toon nette lege staat
-        titleEl.textContent = slug.replace(/-/g,' ').replace(/\b\w/g, c => c.toUpperCase());
-        document.getElementById('post-date').textContent = '-';
-        document.getElementById('post-read-time').textContent = '-';
+        dateEl.textContent = '-';
+        readTimeEl.textContent = '-';
         contentEl.innerHTML = '<p>Deze blog post is nog leeg.</p>';
         return;
       }
 
-      // Toon post data
-      console.log('Rendering post data:', post);
-      document.title = (post.metaTitle || post.title || titleEl.textContent) + ' - Vitalora';
-      titleEl.textContent = post.title || titleEl.textContent;
-      console.log('Title set to:', titleEl.textContent);
-      
-      if (post.publishedDate) {
-        if (metaEl) { metaEl.textContent = '/' + slug + ' · ' + post.publishedDate + (post.readTime ? (' · ' + post.readTime + ' min') : ''); }
-        document.getElementById('post-date').textContent = post.publishedDate;
-        document.getElementById('post-read-time').textContent = (post.readTime || 5) + ' min';
-        console.log('Meta data set');
+      if (post.status && post.status !== 'published' && !hasStaffAccess()) {
+        titleEl.textContent = 'Artikel niet gepubliceerd';
+        dateEl.textContent = '-';
+        readTimeEl.textContent = '-';
+        contentEl.innerHTML = '<p>Dit artikel is nog niet beschikbaar.</p>';
+        if (featuredWrap) {
+          featuredWrap.textContent = 'Afbeelding placeholder';
+        }
+        return;
       }
-      
-      if (post.content && post.content.trim()) {
-        console.log('Setting content from post.content');
+
+      document.title = (post.metaTitle || post.title || slugToTitle(slug)) + ' - Vitalora';
+      titleEl.textContent = post.title || slugToTitle(slug);
+
+      const displayDate = post.publishedDate || post.publishDate || '';
+      dateEl.textContent = displayDate || '-';
+      readTimeEl.textContent = formatReadTime(post.readTime) + ' min';
+
+      if (post.content && typeof post.content === 'string' && post.content.trim()) {
         contentEl.innerHTML = post.content;
       } else if (post.text || post.excerpt) {
-        console.log('Setting content from post.text/excerpt');
-        contentEl.textContent = (post.text || post.excerpt);
+        contentEl.textContent = post.text || post.excerpt;
       } else {
-        console.log('No content found, showing empty state');
         contentEl.innerHTML = '<p>Deze blog post is nog leeg.</p>';
       }
-      
-      console.log('Content element innerHTML:', contentEl.innerHTML);
 
-      // Extra guard: some environments/scripts may try to reset the template.
-      // Keep the rendered title/content stable by restoring if they get overwritten.
+      normalizeSummaryHeaders();
+
       try {
         function enforceRender(){
           try {
-            if (titleEl && (titleEl.textContent || '').trim().toLowerCase() === 'laden...') {
-              titleEl.textContent = post.title || titleEl.textContent;
+            if (titleEl && !titleEl.textContent.trim()) {
+              titleEl.textContent = post.title || slugToTitle(slug);
             }
             if (contentEl) {
-              var html = (contentEl.innerHTML || '').trim();
+              const html = (contentEl.innerHTML || '').trim();
               if (!html || html === 'Nog invullen.' || html.indexOf('Nog invullen') !== -1) {
                 contentEl.innerHTML = post.content || '<p>Deze blog post is nog leeg.</p>';
               }
             }
-          } catch(_) {}
+          } catch (_) {}
         }
-        // Observe future mutations and re-apply if needed
-        var contentObserver = new MutationObserver(function(muts){ enforceRender(); });
-        contentObserver.observe(contentEl, { childList: true, characterData: true, subtree: true });
-        // Re-enforce a few times after load as belt-and-suspenders
+        const observer = new MutationObserver(function(){ enforceRender(); });
+        observer.observe(contentEl, { childList: true, characterData: true, subtree: true });
         setTimeout(enforceRender, 100);
         setTimeout(enforceRender, 600);
         setTimeout(enforceRender, 1500);
-      } catch(_) {}
+      } catch (_) {}
 
-      // Featured image handling
       try {
-        const featuredWrap = document.getElementById('featured-image');
         if (featuredWrap) {
-          if (post.featuredImage && typeof post.featuredImage === 'string' && post.featuredImage.trim() !== '') {
+          if (post.featuredImage && typeof post.featuredImage === 'string' && post.featuredImage.trim()) {
             const img = document.createElement('img');
             img.src = post.featuredImage;
             img.alt = post.title || slug;
             featuredWrap.innerHTML = '';
             featuredWrap.appendChild(img);
           } else {
-            // Fallback: try first image from content if present
             const tmp = document.createElement('div');
             tmp.innerHTML = post.content || '';
             const firstImg = tmp.querySelector('img');
@@ -217,39 +277,23 @@
             }
           }
         }
-      } catch (e) {
-        console.log('Error rendering featured image:', e);
+      } catch (error) {
+        console.warn('Kon headerafbeelding niet renderen:', error);
       }
 
-      // Zet canonical naar pretty URL
-      (function setCanonical(){
+      try {
         var canonical = document.querySelector('link[rel="canonical"]');
-        if(!canonical){
+        if (!canonical) {
           canonical = document.createElement('link');
-          canonical.setAttribute('rel','canonical');
+          canonical.setAttribute('rel', 'canonical');
           document.head.appendChild(canonical);
         }
         canonical.setAttribute('href', location.origin + '/' + encodeURIComponent(slug));
-      })();
+      } catch (_) {}
 
-      // Normalize summary headers label to "In het kort..." on render
-      (function normalizeSummaryHeaders(){
-        try {
-          var headers = document.querySelectorAll('.summary-header');
-          headers.forEach(function(h){
-            // Preserve icon, replace label
-            var icon = h.querySelector('.icon');
-            h.innerHTML = '';
-            var iconEl = document.createElement('div');
-            iconEl.className = 'icon';
-            iconEl.textContent = '📋';
-            h.appendChild(iconEl);
-            h.appendChild(document.createTextNode(' In het kort...'));
-          });
-        } catch(_) {}
-      })();
-
-      console.log('=== POST TEMPLATE SCRIPT END ===');
+      if (post && (post.id || post.slug)) {
+        cachePost(post);
+      }
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace the sqlite CLI handler with a Postgres-backed `/api/blogs` implementation that creates the table on demand and validates input/slug conflicts
- update `blog.html` and `post.html` to fetch posts from the API first, keep local fallbacks, and guard unpublished articles behind the staff cookie
- document the new Postgres requirement and add the `pg` dependency needed for the API

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c93dcfc83c8329a6053aab302f4ff7