### PR TITLE
Fix footer alignment on short blog pages

### DIFF
--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -36,6 +36,18 @@ footer a[style*="font-weight: 700"] {
 }
 
 /* Base footer styling for all pages (not just homepage) */
+/* Keep the footer at the bottom when a page has little content. */
+body:has(> footer) {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+body:has(> footer) > footer {
+  flex: 0 0 auto;
+  margin-top: auto;
+}
+
 footer {
   background-color: #374151 !important;
   color: white !important;
@@ -252,4 +264,3 @@ footer .brand-email { text-decoration: none !important; }
     text-align: left !important;
   }
 }
-

--- a/blog.html
+++ b/blog.html
@@ -7,7 +7,7 @@
 	<link rel="stylesheet" href="styles.css?v=2">
 	<link rel="stylesheet" href="/assets/css/header.css">
 	<link rel="stylesheet" href="/assets/css/fonts.css?v=12">
-	<link rel="stylesheet" href="/assets/css/footer.css?v=12">
+	<link rel="stylesheet" href="/assets/css/footer.css?v=13">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">

--- a/blog/index.html
+++ b/blog/index.html
@@ -7,7 +7,7 @@
 	<link rel="stylesheet" href="styles.css?v=2">
 	<link rel="stylesheet" href="/assets/css/header.css">
 	<link rel="stylesheet" href="/assets/css/fonts.css?v=12">
-	<link rel="stylesheet" href="/assets/css/footer.css?v=12">
+	<link rel="stylesheet" href="/assets/css/footer.css?v=13">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Fixes the empty white strip below the footer on short blog pages by anchoring the footer to the viewport bottom. Also bumps the blog footer stylesheet cache version.