### PR TITLE
Allow 000000 Academy access code

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -140,7 +140,8 @@
         enterButton.addEventListener('click', function(e){
           e.preventDefault();
           const code = Array.from(pinInputs).map(input => input.value).join('');
-          if(code === '058267') {
+          const validCodes = new Set(['058267', '000000']);
+          if(validCodes.has(code)) {
             try { sessionStorage.setItem('academySession','ok'); } catch(e){}
             window.location.href='/academy';
           } else {
@@ -156,5 +157,4 @@
     </script>
 </body>
 </html>
-
 


### PR DESCRIPTION
## What changed
- Accept `000000` as an additional Academy access code.
- Keep the existing `058267` code working.
- Continue rejecting other codes.

## Validation
- Browser-flow harness verified both valid codes redirect to `/academy` and invalid codes remain rejected.
- `git diff --check` passed.

This is an intentional public access code requested by the site owner.