### PR TITLE
Narrow lesson reader content

### DIFF
--- a/lesson-view.html
+++ b/lesson-view.html
@@ -401,7 +401,7 @@
     }
 
     .lesson-container {
-      max-width: 1240px;
+      max-width: 1040px;
       padding: 12px 18px 28px;
       z-index: 2;
     }
@@ -507,9 +507,9 @@
     }
 
     .lesson-content {
-      max-width: 1120px;
+      max-width: 920px;
       margin: 0 auto 12px;
-      padding: 20px 34px;
+      padding: 20px 28px;
       background: var(--reader-paper);
       border: 1px solid #e8edf4;
       border-top: 2px solid var(--brand);
@@ -522,7 +522,7 @@
     }
 
     .content-section {
-      max-width: 1000px;
+      max-width: 780px;
       margin: 0 auto;
     }
 
@@ -605,7 +605,7 @@
       grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
       align-items: center;
       gap: 8px;
-      max-width: 1120px;
+      max-width: 920px;
       margin: 0 auto;
       padding: 10px 0 0;
       background: transparent;


### PR DESCRIPTION
## Wat verandert er
- vernauwt de complete reader naar een rustigere pagina-marge
- maakt de contentkaart smaller
- beperkt de leeskolom zodat tekstregels niet meer over het scherm doorlopen
- houdt de bestaande compacte typografie en navigatie intact

## Validatie
- `git diff --check`
- inline JavaScript parsing
- inline CSS-brace check