### PR TITLE
Remove course reader footer and inner scrollbar

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -8,15 +8,15 @@
 
 :root {
   --sidebar-w: 272px;
-  --sidebar-bg: #112b43;
-  --sidebar-border: rgba(255, 255, 255, 0.09);
-  --sidebar-text: #a8bdcf;
+  --sidebar-bg: #2954b3;
+  --sidebar-border: rgba(255, 255, 255, 0.14);
+  --sidebar-text: #d7e5f3;
   --sidebar-active: #f4f9ff;
-  --sidebar-muted: #6f8aa1;
+  --sidebar-muted: #a9c1d9;
   --sidebar-hover: rgba(255, 255, 255, 0.05);
-  --sidebar-selected: rgba(58, 154, 234, 0.13);
+  --sidebar-selected: rgba(58, 154, 234, 0.24);
   --brand: #3a9aea;
-  --brand-dark: #2563eb;
+  --brand-dark: #2954b3;
   --brand-rgb: 58, 154, 234;
   --content-bg: #f8f5f0;
   --surface: #ffffff;
@@ -61,15 +61,17 @@ button {
 
 /* Sidebar */
 .sidebar {
-  position: sticky;
+  position: relative;
   top: 0;
   z-index: 30;
   display: flex;
   flex: 0 0 var(--sidebar-w);
+  align-self: flex-start;
   flex-direction: column;
   width: var(--sidebar-w);
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+  height: auto;
+  overflow: visible;
   color: var(--sidebar-text);
   background: var(--sidebar-bg);
   border-right: 1px solid var(--sidebar-border);
@@ -164,21 +166,10 @@ button {
 }
 
 .s-nav {
-  flex: 1;
+  flex: 0 0 auto;
   min-height: 0;
   padding: 4px 0 20px;
-  overflow-y: auto;
-  scrollbar-color: rgba(255, 255, 255, 0.16) transparent;
-  scrollbar-width: thin;
-}
-
-.s-nav::-webkit-scrollbar {
-  width: 3px;
-}
-
-.s-nav::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 2px;
+  overflow: visible;
 }
 
 .s-ch-label {
@@ -287,9 +278,7 @@ button {
 
 .topbar-l,
 .rt-badge,
-.tags,
-.btn-group,
-.footer-inner {
+.tags {
   display: flex;
   align-items: center;
 }
@@ -301,7 +290,6 @@ button {
 
 .tb-label,
 .lesson-num-label,
-.footer-meta-top,
 .sec-eyebrow {
   font-size: 10px;
   font-weight: 700;
@@ -352,7 +340,7 @@ button {
   width: 100%;
   max-width: 720px;
   margin: 0 auto;
-  padding: 0 56px;
+  padding: 0 56px 64px;
 }
 
 .lesson-head {
@@ -531,98 +519,6 @@ h1.title {
   text-transform: uppercase;
 }
 
-.lesson-footer {
-  margin-top: 0;
-  padding: 26px 56px 40px;
-  border-top: 1px solid var(--line);
-}
-
-.footer-inner {
-  justify-content: space-between;
-  width: min(720px, 100%);
-  margin: 0 auto;
-  gap: 16px;
-}
-
-.footer-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.footer-meta-top {
-  color: var(--muted);
-}
-
-.footer-meta-sub {
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.btn-group {
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.btn,
-.btn-done {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 10px 20px;
-  border-radius: 7px;
-  font-size: 13.5px;
-  font-weight: 600;
-  text-decoration: none;
-  cursor: pointer;
-  transition: color 0.16s ease, background 0.16s ease, border-color 0.16s ease, transform 0.16s ease;
-}
-
-.btn-ghost,
-.btn-done {
-  padding: 9px 16px;
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.btn-done svg {
-  width: 14px;
-  height: 14px;
-}
-
-.btn-done {
-  color: var(--body-text);
-  background: transparent;
-  border: 1px solid var(--line);
-}
-
-.btn-ghost:hover,
-.btn-done:hover {
-  color: var(--ink);
-  background: var(--surface);
-  border-color: #d5cec4;
-}
-
-.btn-primary {
-  color: #fff;
-  background: var(--brand);
-  border: 1px solid var(--brand);
-}
-
-.btn-primary:hover {
-  background: var(--brand-dark);
-  border-color: var(--brand-dark);
-  box-shadow: 0 4px 14px rgba(var(--brand-rgb), 0.28);
-  transform: translateY(-1px);
-}
-
-.btn-done.done {
-  color: var(--brand-dark);
-  background: var(--soft-brand);
-  border-color: var(--brand);
-}
-
 .reader-error {
   padding: 18px;
   color: #b42318;
@@ -636,37 +532,22 @@ h1.title {
 }
 
 @media (max-width: 760px) {
-  .sidebar {
-    position: fixed;
-    left: 0;
-    transform: translateX(-100%);
-    transition: transform 0.2s ease;
-    box-shadow: 14px 0 30px rgba(10, 25, 40, 0.2);
+  body {
+    display: block;
   }
 
-  body.sidebar-open .sidebar {
-    transform: translateX(0);
+  .sidebar {
+    width: 100%;
+    min-height: 0;
+    box-shadow: none;
   }
 
   .mobile-menu {
-    display: inline-grid;
-    place-items: center;
+    display: none;
   }
 
   .sidebar-scrim {
-    position: fixed;
-    inset: 0;
-    z-index: 25;
-    display: block;
-    visibility: hidden;
-    background: rgba(12, 28, 43, 0.32);
-    opacity: 0;
-    transition: visibility 0.2s ease, opacity 0.2s ease;
-  }
-
-  body.sidebar-open .sidebar-scrim {
-    visibility: visible;
-    opacity: 1;
+    display: none;
   }
 
   .topbar {
@@ -711,18 +592,6 @@ h1.title {
     line-height: 1.72;
   }
 
-  .lesson-footer {
-    padding: 22px 20px 30px;
-  }
-
-  .footer-inner {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .btn-group {
-    justify-content: flex-start;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/js/course-view.js
+++ b/assets/js/course-view.js
@@ -87,8 +87,7 @@
     lessons: [],
     groups: [],
     current: null,
-    completed: new Set(),
-    done: false
+    completed: new Set()
   };
 
   const $ = (selector) => document.querySelector(selector);
@@ -161,27 +160,6 @@
   function lessonView(lesson) {
     const override = readerOverrides[`${state.slug}:${lesson.index}`];
     return override ? { ...lesson, ...override } : lesson;
-  }
-
-  function writeCompletion(lesson, done) {
-    try {
-      const stored = JSON.parse(localStorage.getItem('completedLessons') || '[]');
-      const values = Array.isArray(stored) ? stored.map(String) : [];
-      const index = values.indexOf(String(lesson.index));
-      if (done && index === -1) values.push(String(lesson.index));
-      if (!done && index !== -1) values.splice(index, 1);
-      localStorage.setItem('completedLessons', JSON.stringify(values));
-      localStorage.setItem(`progress:${state.slug}:${lesson.id}:done`, String(done));
-    } catch (error) {
-      // The reader remains usable even when progress cannot be persisted.
-    }
-    if (done) {
-      state.completed.add(String(lesson.index));
-      state.completed.add(String(lesson.id));
-    } else {
-      state.completed.delete(String(lesson.index));
-      state.completed.delete(String(lesson.id));
-    }
   }
 
   function shortTitle(title) {
@@ -297,21 +275,12 @@
     return '<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="6" cy="6" r="5"/><path d="M6 3.5v2.75L7.5 8"/></svg>';
   }
 
-  function checkIcon() {
-    return '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="m3 8.5 3.5 3.5 6.5-7"/></svg>';
-  }
-
   function renderLesson() {
     const view = lessonView(state.current);
-    const index = state.lessons.findIndex((lesson) => lesson.id === state.current.id);
-    const previous = index > 0 ? state.lessons[index - 1] : null;
-    const next = index < state.lessons.length - 1 ? state.lessons[index + 1] : null;
     const content = view.lead
       ? { lead: view.lead, html: view.content_html }
       : extractContent(state.current);
     const chapter = getChapterNumber(state.current);
-    const complete = isComplete(state.current);
-    state.done = complete;
 
     $('#sCourse').textContent = (displayTitles[state.slug] || state.course.title || 'Cursus').split(':')[0];
     $('#tbLabel').textContent = `Les ${String(state.current.index).padStart(2, '0')}`;
@@ -325,13 +294,6 @@
       <span class="tag tag-o">${escapeHTML(view.type || state.course.level || 'Theorie')}</span>
       <span class="tag tag-o">Hoofdstuk ${chapter}</span>`;
     $('#lessonContent').innerHTML = decorateContent(content.html);
-    $('#footerMeta').textContent = `Les ${state.current.index} van ${state.lessons.length} · Hoofdstuk ${chapter}`;
-    $('#doneBtn').classList.toggle('done', complete);
-    $('#doneBtn').innerHTML = complete ? `${checkIcon()} Voltooid` : `${checkIcon()} Markeer als voltooid`;
-    $('#prevBtn').href = previous ? lessonHref(previous) : '/academy';
-    $('#prevBtn').textContent = previous ? '← Vorige' : '← Academy';
-    $('#nextBtn').href = next ? lessonHref(next) : '/academy';
-    $('#nextBtn').textContent = next ? 'Volgende les →' : 'Cursus voltooid →';
   }
 
   function renderPage() {
@@ -363,17 +325,6 @@
         document.body.classList.remove('sidebar-open');
         menu?.setAttribute('aria-expanded', 'false');
       }
-    });
-
-    $('#doneBtn')?.addEventListener('click', () => {
-      state.done = !state.done;
-      writeCompletion(state.current, state.done);
-      renderSidebar();
-      renderLesson();
-    });
-
-    $('#nextBtn')?.addEventListener('click', () => {
-      if (!state.done) writeCompletion(state.current, true);
     });
 
     window.addEventListener('scroll', () => {

--- a/course-view.html
+++ b/course-view.html
@@ -47,7 +47,7 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=2">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=4">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">
@@ -103,22 +103,8 @@
         <p>Lesinhoud laden...</p>
       </article>
     </div>
-
-    <footer class="lesson-footer">
-      <div class="footer-inner">
-        <div class="footer-meta">
-          <div class="footer-meta-top">Voortgang</div>
-          <div class="footer-meta-sub" id="footerMeta">Les laden...</div>
-        </div>
-        <div class="btn-group">
-          <button class="btn-done" id="doneBtn" type="button">✓ Markeer als voltooid</button>
-          <a class="btn btn-ghost cta-button" id="prevBtn" href="/academy">← Vorige</a>
-          <a class="btn btn-primary cta-button" id="nextBtn" href="/academy">Volgende les →</a>
-        </div>
-      </div>
-    </footer>
   </main>
 
-  <script src="/assets/js/course-view.js?v=3" defer></script>
+  <script src="/assets/js/course-view.js?v=5" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Wat verandert er
- verwijdert de volledige footer onderaan een les
- maakt de cursusnavigatie volledig zichtbaar zonder interne scrollbar
- laat de normale pagina naar beneden scrollen, ook op smalle schermen
- gebruikt het lichtere Vitalora-blauw voor de reader-sidebar
- ruimt de nu overbodige footer-JavaScript op

## Gecontroleerd
- `node --check assets/js/course-view.js`
- `git diff --check`
- lokale reader gecontroleerd op desktop en 336px mobiele breedte
- 51 lessen zichtbaar, navigatie-overflow `visible`, geen footer aanwezig en geen browserfouten