### PR TITLE
Polish course sidebar emphasis

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -100,6 +100,11 @@ button {
   color: var(--sidebar-active);
 }
 
+.s-back {
+  color: var(--sidebar-active);
+  font-weight: 600;
+}
+
 .s-back svg {
   width: 12px;
   height: 12px;
@@ -143,8 +148,12 @@ button {
   text-transform: uppercase;
 }
 
+.s-prog-label {
+  color: var(--sidebar-active);
+}
+
 .s-prog-count {
-  color: var(--brand);
+  color: var(--sidebar-active);
   font-size: 11px;
   font-weight: 700;
 }
@@ -216,7 +225,7 @@ button {
 }
 
 .s-lesson.active .s-num {
-  color: var(--brand);
+  color: var(--sidebar-active);
 }
 
 .s-lesson-title {

--- a/course-view.html
+++ b/course-view.html
@@ -47,7 +47,7 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=6">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=7">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">


### PR DESCRIPTION
## Wat is aangepast
- `Cursusoverzicht` is nu wit en vetgedrukt, gelijk aan `Vitalora`.
- `Voortgang` en `3 / 51` zijn wit en duidelijk leesbaar.
- Het actieve lesnummer `04` is wit in plaats van blauw.
- De stylesheet-cacheversie is verhoogd zodat productie de wijziging direct laadt.

## Controle
- `node --check assets/js/course-view.js`
- `node --check assets/js/lesson-view.js`
- `git diff --check`