### PR TITLE
Make active lesson marker white

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -208,7 +208,7 @@ button {
 .s-lesson.active {
   color: var(--sidebar-active);
   background: var(--sidebar-selected);
-  border-left-color: var(--brand);
+  border-left-color: var(--sidebar-active);
 }
 
 .s-lesson.complete .s-dot {

--- a/course-view.html
+++ b/course-view.html
@@ -47,7 +47,7 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=7">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=8">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">


### PR DESCRIPTION
## Wat is aangepast
- Het verticale markeerbalkje van de actieve les is wit gemaakt, zodat het niet meer blauw afwijkt van de witte actieve lesinformatie.
- De stylesheet-cacheversie is verhoogd zodat productie de wijziging direct laadt.

## Controle
- `node --check assets/js/course-view.js`
- `node --check assets/js/lesson-view.js`
- `git diff --check`