### PR TITLE
Simplify course reader brand link

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -83,40 +83,26 @@ button {
   border-bottom: 1px solid var(--sidebar-border);
 }
 
-.s-back,
 .s-logo {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: var(--sidebar-muted);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  text-decoration: none;
-  transition: color 0.16s ease;
-}
-
-.s-back:hover {
-  color: var(--sidebar-active);
-}
-
-.s-back {
-  color: var(--sidebar-active);
-  font-weight: 600;
-}
-
-.s-back svg {
-  width: 12px;
-  height: 12px;
-}
-
-.s-logo {
-  display: block;
-  margin-top: 0;
+  gap: 8px;
   color: var(--sidebar-active);
   font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.01em;
+  text-decoration: none;
+  transition: color 0.16s ease;
+}
+
+.s-logo:hover {
+  color: var(--sidebar-active);
+}
+
+.s-logo svg {
+  flex: 0 0 12px;
+  width: 12px;
+  height: 12px;
 }
 
 .s-course {

--- a/course-view.html
+++ b/course-view.html
@@ -47,18 +47,17 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=8">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=9">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">
     <div class="s-brand">
-      <a class="s-back" href="/academy">
+      <a class="s-logo" href="/academy" aria-label="Terug naar Vitalora Academy">
         <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
           <path d="M8 2 4 6l4 4"/>
         </svg>
-        Cursusoverzicht
+        Vitalora
       </a>
-      <a class="s-logo" href="/academy" aria-label="Terug naar Vitalora Academy">Vitalora</a>
       <div class="s-course" id="sCourse">Clean Reset</div>
     </div>
 


### PR DESCRIPTION
## Wat is aangepast
- `Cursusoverzicht` is verwijderd uit de cursus-sidebar.
- De terugpijl staat nu direct vóór `Vitalora`.
- De volledige pijl + Vitalora-regel blijft naar Academy linken.
- De stylesheet-cacheversie is verhoogd zodat productie de nieuwe header direct laadt.

## Controle
- `node --check assets/js/course-view.js`
- `node --check assets/js/lesson-view.js`
- `git diff --check`