### PR TITLE
Move lesson duration beside lesson number

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -350,6 +350,18 @@ button {
   color: var(--muted);
 }
 
+.lesson-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  margin-bottom: 12px;
+}
+
+.lesson-meta .lesson-num-label {
+  margin-bottom: 0;
+}
+
 h1.title {
   margin: 0 0 17px;
   color: var(--ink);
@@ -384,6 +396,12 @@ h1.title {
   white-space: nowrap;
 }
 
+.tag svg {
+  flex: 0 0 12px;
+  width: 12px;
+  height: 12px;
+}
+
 .tag-g {
   color: var(--brand-dark);
   background: var(--soft-brand);
@@ -394,6 +412,10 @@ h1.title {
   color: var(--body-text);
   background: var(--surface);
   border: 1px solid var(--line);
+}
+
+.lesson-duration {
+  margin: 0;
 }
 
 .content {

--- a/assets/js/course-view.js
+++ b/assets/js/course-view.js
@@ -287,10 +287,10 @@
     $('#tbTitle').textContent = shortTitle(view.title);
     $('#rtBadge').textContent = `${view.duration_min || 10} min leestijd`;
     $('#lessonNumber').textContent = `Les ${String(state.current.index).padStart(2, '0')} van ${state.lessons.length}`;
+    $('#lessonDuration').innerHTML = `${clockIcon()} ${view.duration_min || 10} minuten`;
     $('#lessonTitle').textContent = shortTitle(view.title);
     $('#lessonLead').textContent = content.lead;
     $('#lessonTags').innerHTML = `
-      <span class="tag tag-g">${clockIcon()} ${view.duration_min || 10} minuten</span>
       <span class="tag tag-o">${escapeHTML(view.type || state.course.level || 'Theorie')}</span>
       <span class="tag tag-o">Hoofdstuk ${chapter}</span>`;
     $('#lessonContent').innerHTML = decorateContent(content.html);

--- a/course-view.html
+++ b/course-view.html
@@ -47,7 +47,7 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=9">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=10">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">
@@ -92,7 +92,10 @@
 
     <div class="wrap">
       <div class="lesson-head">
-        <div class="lesson-num-label" id="lessonNumber">Les 01 van 0</div>
+        <div class="lesson-meta">
+          <div class="lesson-num-label" id="lessonNumber">Les 01 van 0</div>
+          <span class="tag tag-o lesson-duration" id="lessonDuration" aria-label="Leestijd"></span>
+        </div>
         <h1 class="title" id="lessonTitle">Les laden...</h1>
         <p class="lesson-lead" id="lessonLead">Even geduld, de les wordt geladen.</p>
         <div class="tags" id="lessonTags"></div>
@@ -104,6 +107,6 @@
     </div>
   </main>
 
-  <script src="/assets/js/course-view.js?v=5" defer></script>
+  <script src="/assets/js/course-view.js?v=6" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Wat is aangepast
- De leestijdbadge `18 minuten` staat nu naast `Les 04 van 51`.
- De badge gebruikt een neutrale kleur en is niet langer blauw.
- `Praktijk` en `Hoofdstuk 1` blijven als losse labels onder de introductietekst staan.
- Cacheversies van de reader-HTML, CSS en JavaScript zijn verhoogd.

## Controle
- `node --check assets/js/course-view.js`
- `node --check assets/js/lesson-view.js`
- `git diff --check`