### PR TITLE
Widen course lesson sidebar

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -7,7 +7,7 @@
 }
 
 :root {
-  --sidebar-w: 272px;
+  --sidebar-w: 360px;
   --sidebar-bg: #2954b3;
   --sidebar-border: rgba(255, 255, 255, 0.14);
   --sidebar-text: #d7e5f3;

--- a/course-view.html
+++ b/course-view.html
@@ -47,7 +47,7 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=10">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=11">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">


### PR DESCRIPTION
## Wat is aangepast
- De cursus-sidebar is verbreed van 272px naar 360px.
- Lesnummers, titels en statusbolletjes houden dezelfde uitlijning, maar lesnamen krijgen meer leesruimte.
- Op smalle schermen blijft de sidebar schermbreed.
- De stylesheet-cacheversie is verhoogd zodat productie de wijziging direct laadt.

## Controle
- `node --check assets/js/course-view.js`
- `node --check assets/js/lesson-view.js`
- `git diff --check`