### PR TITLE
Stabilize sidebar lesson navigation

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -365,10 +365,11 @@ button {
 h1.title {
   margin: 0 0 17px;
   color: var(--ink);
-  font-size: clamp(28px, 4vw, 44px);
+  font-size: clamp(28px, 4vw, 40px);
   font-weight: 600;
   letter-spacing: -0.035em;
   line-height: 1.13;
+  white-space: nowrap;
 }
 
 .lesson-lead {
@@ -598,6 +599,7 @@ h1.title {
 
   h1.title {
     font-size: clamp(28px, 9vw, 38px);
+    white-space: normal;
   }
 
   .lesson-lead {

--- a/assets/js/course-view.js
+++ b/assets/js/course-view.js
@@ -170,6 +170,17 @@
     return `/course-view.html?course=${encodeURIComponent(state.slug)}&lesson=${encodeURIComponent(lesson.index)}`;
   }
 
+  function lessonPath(slug, lesson) {
+    const alias = slugToAlias[slug];
+    return alias
+      ? `/${alias}?lesson=${encodeURIComponent(lesson.index)}`
+      : `/course-view.html?course=${encodeURIComponent(slug)}&lesson=${encodeURIComponent(lesson.index)}`;
+  }
+
+  function updateLessonUrl(slug, lesson, method) {
+    window.history[method]({ course: slug, lesson: lesson.index }, '', lessonPath(slug, lesson));
+  }
+
   function buildGroups() {
     const blueprint = state.slug === 'clean-reset' ? cleanResetChapters : null;
     if (blueprint) {
@@ -207,7 +218,8 @@
         return `
           <a class="s-lesson${active ? ' active' : ''}${complete ? ' complete' : ''}"
              href="${lessonHref(lesson)}"
-             title="${escapeHTML(view.title)}">
+             data-lesson-index="${escapeHTML(lesson.index)}"
+             aria-label="${escapeHTML(view.title)}"${active ? ' aria-current="page"' : ''}>
             <span class="s-num">${String(lesson.index).padStart(2, '0')}</span>
             <span class="s-lesson-title">${escapeHTML(shortTitle(view.title))}</span>
             <span class="s-dot" aria-hidden="true"></span>
@@ -298,9 +310,32 @@
 
   function renderPage() {
     const title = displayTitles[state.slug] || state.course.title || 'Cursus';
-    document.title = `${shortTitle(lessonView(state.current).title)} | ${title} | Vitalora`;
+    updateDocumentTitle();
     $('#sCourse').textContent = title.split(':')[0];
     renderSidebar();
+    renderLesson();
+  }
+
+  function updateDocumentTitle() {
+    const title = displayTitles[state.slug] || state.course.title || 'Cursus';
+    document.title = `${shortTitle(lessonView(state.current).title)} | ${title} | Vitalora`;
+  }
+
+  function updateSidebarActive() {
+    document.querySelectorAll('#sNav .s-lesson').forEach((link) => {
+      const active = link.dataset.lessonIndex === String(state.current.index);
+      link.classList.toggle('active', active);
+      if (active) link.setAttribute('aria-current', 'page');
+      else link.removeAttribute('aria-current');
+    });
+  }
+
+  function showLesson(lesson, { push = false } = {}) {
+    if (!lesson) return;
+    state.current = lesson;
+    if (push) updateLessonUrl(state.slug, lesson, 'pushState');
+    updateSidebarActive();
+    updateDocumentTitle();
     renderLesson();
   }
 
@@ -312,6 +347,15 @@
 
   function setupReaderInteractions() {
     const menu = $('#mobileMenu');
+    const nav = $('#sNav');
+    nav?.addEventListener('click', (event) => {
+      const link = event.target.closest('a.s-lesson');
+      if (!link || (event.button !== undefined && event.button !== 0) || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      const requested = state.lessons.find((lesson) => String(lesson.index) === link.dataset.lessonIndex);
+      if (!requested) return;
+      event.preventDefault();
+      if (requested.index !== state.current.index) showLesson(requested, { push: true });
+    });
     menu?.addEventListener('click', () => {
       const open = document.body.classList.toggle('sidebar-open');
       menu.setAttribute('aria-expanded', String(open));
@@ -332,6 +376,15 @@
       const percentage = max > 0 ? Math.min(100, (window.scrollY / max) * 100) : 0;
       $('#rFill').style.width = `${percentage}%`;
     }, { passive: true });
+    window.addEventListener('popstate', () => {
+      const locationState = getLocationState();
+      if (locationState.slug !== state.slug) {
+        window.location.reload();
+        return;
+      }
+      const requested = state.lessons.find((lesson) => String(lesson.index) === String(locationState.lessonParam));
+      if (requested) showLesson(requested);
+    });
   }
 
   async function loadReader() {

--- a/course-view.html
+++ b/course-view.html
@@ -47,7 +47,7 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=11">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=12">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">
@@ -107,6 +107,6 @@
     </div>
   </main>
 
-  <script src="/assets/js/course-view.js?v=6" defer></script>
+  <script src="/assets/js/course-view.js?v=7" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Wat is aangepast
- Klikken op een les navigeert nu zonder volledige paginareload, zodat de sidebar niet opnieuw inspringt.
- De sidebar behoudt zijn positie en de actieve les wordt direct bijgewerkt.
- Browser terug/vooruit werkt met dezelfde in-page navigatie.
- De native hover-tooltip op lesregels is vervangen door een toegankelijk label.
- `Wat toxines met je lichaam doen` blijft op één regel op desktop en blijft responsief op smalle schermen.
- Cacheversies zijn verhoogd voor de gewijzigde CSS en JavaScript.

## Controle
- `node --check assets/js/course-view.js`
- `node --check assets/js/lesson-view.js`
- `git diff --check`