### PR TITLE
Align lesson metadata beside lesson number

### DIFF
--- a/assets/js/course-view.js
+++ b/assets/js/course-view.js
@@ -78,6 +78,7 @@
     39: 'Ademhaling & stress',
     40: 'Ontspanning & detox',
     41: 'Detox-voeding & supplementen',
+    44: 'Zwavelverbindingen & detox',
     45: 'Supplementen voor detox',
     46: 'Toxines in je leefomgeving',
     48: 'Huisstof & toxines',

--- a/course-view.html
+++ b/course-view.html
@@ -95,10 +95,10 @@
         <div class="lesson-meta">
           <div class="lesson-num-label" id="lessonNumber">Les 01 van 0</div>
           <span class="tag tag-o lesson-duration" id="lessonDuration" aria-label="Leestijd"></span>
+          <div class="tags" id="lessonTags"></div>
         </div>
         <h1 class="title" id="lessonTitle">Les laden...</h1>
         <p class="lesson-lead" id="lessonLead">Even geduld, de les wordt geladen.</p>
-        <div class="tags" id="lessonTags"></div>
       </div>
 
       <article class="content" id="lessonContent" aria-live="polite">
@@ -107,6 +107,6 @@
     </div>
   </main>
 
-  <script src="/assets/js/course-view.js?v=8" defer></script>
+  <script src="/assets/js/course-view.js?v=9" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Wat is aangepast
- “Praktijk” en “Hoofdstuk 1” staan nu naast “Les 04 van 51” in dezelfde metadatazone.
- De metadata mag op kleinere schermen netjes doorlopen.
- De laatste lange zijbalktitel (“Zwavelverbindingen…”) is ook ingekort zodat die volledig past.

## Controle
- `git diff --check`
- `node --check assets/js/course-view.js`
- Vercel preview-build wordt gecontroleerd voor productie.