### PR TITLE
Rebuild Clean Reset as a premium 24-lesson course

### DIFF
--- a/assets/css/course-reader.css
+++ b/assets/css/course-reader.css
@@ -531,6 +531,233 @@ h1.title {
   margin-bottom: 0;
 }
 
+.lesson-opening {
+  margin: 0 0 52px;
+  padding: 0 0 30px;
+  border-bottom: 1px solid var(--line);
+}
+
+.lesson-opening p:first-child {
+  color: var(--ink);
+  font-size: 17px;
+  line-height: 1.82;
+}
+
+.lesson-callout {
+  margin: 28px 0 0;
+  padding: 18px 20px;
+  background: rgba(var(--brand-rgb), 0.075);
+  border: 1px solid rgba(var(--brand-rgb), 0.2);
+  border-radius: 10px;
+}
+
+.lesson-callout-warning {
+  background: #fff7f2;
+  border-color: #eed6c7;
+}
+
+.lesson-callout p {
+  margin: 4px 0 0;
+  font-size: 14.5px;
+  line-height: 1.7;
+}
+
+.callout-label,
+.action-kicker,
+.remember-kicker {
+  color: var(--brand-dark);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lesson-callout-warning .callout-label {
+  color: #a74d27;
+}
+
+.course-figure {
+  margin: -10px 0 60px;
+}
+
+.course-figure img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(24, 34, 44, 0.1);
+}
+
+.course-figure figcaption {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+
+.lesson-action {
+  margin: 68px 0 34px;
+  padding: 28px 30px 30px;
+  color: var(--body-text);
+  background: linear-gradient(145deg, rgba(var(--brand-rgb), 0.12), rgba(var(--brand-rgb), 0.055));
+  border: 1px solid rgba(var(--brand-rgb), 0.23);
+  border-radius: 14px;
+}
+
+.action-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 12px;
+}
+
+.action-time {
+  color: var(--brand-dark);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.lesson-action h2,
+.lesson-remember h2,
+.lesson-sources h2 {
+  margin: 0 0 14px;
+}
+
+.lesson-action > p {
+  margin-bottom: 18px;
+  font-size: 14.5px;
+  line-height: 1.7;
+}
+
+.content ol.step-list {
+  counter-reset: lesson-step;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 22px 0 0;
+  list-style: none;
+}
+
+.content ol.step-list li {
+  counter-increment: lesson-step;
+  display: grid;
+  grid-template-columns: 27px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+.content ol.step-list li::before {
+  content: counter(lesson-step);
+  display: grid;
+  place-items: center;
+  width: 27px;
+  height: 27px;
+  margin-top: 1px;
+  color: #fff;
+  background: var(--brand);
+  border-radius: 50%;
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.reflection {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid rgba(var(--brand-rgb), 0.2);
+}
+
+.reflection > span {
+  color: var(--brand-dark);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.reflection p {
+  margin: 5px 0 0;
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+.lesson-remember {
+  margin: 34px 0;
+  padding: 26px 0 30px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.lesson-remember .flist {
+  margin-bottom: 0;
+}
+
+.lesson-remember .flist li {
+  color: var(--ink);
+  font-size: 14.5px;
+  font-weight: 550;
+  line-height: 1.6;
+}
+
+.lesson-sources {
+  margin: 36px 0 20px;
+  padding: 24px;
+  background: var(--surface);
+  border: 1px solid var(--line-light);
+  border-radius: 10px;
+}
+
+.lesson-sources h2 {
+  font-size: 18px;
+}
+
+.lesson-sources > p {
+  margin-bottom: 14px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.content .lesson-sources ul {
+  gap: 8px;
+  margin: 0;
+}
+
+.content .lesson-sources li {
+  display: block;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.content .lesson-sources li::before {
+  display: none;
+}
+
+.lesson-sources a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 9px 0;
+  color: var(--brand-dark);
+  border-bottom: 1px solid var(--line-light);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.lesson-sources li:last-child a {
+  border-bottom: 0;
+}
+
+.lesson-sources a:hover {
+  color: var(--brand);
+}
+
 .sec-eyebrow {
   margin-bottom: 8px;
   color: var(--brand);
@@ -612,6 +839,25 @@ h1.title {
   .content li {
     font-size: 14.5px;
     line-height: 1.72;
+  }
+
+  .lesson-opening {
+    margin-bottom: 40px;
+    padding-bottom: 22px;
+  }
+
+  .lesson-opening p:first-child {
+    font-size: 15.5px;
+    line-height: 1.72;
+  }
+
+  .lesson-action {
+    margin-top: 48px;
+    padding: 23px 20px 24px;
+  }
+
+  .course-figure {
+    margin-bottom: 44px;
   }
 
 }

--- a/assets/js/course-view.js
+++ b/assets/js/course-view.js
@@ -26,7 +26,7 @@
   };
 
   const displayTitles = {
-    'clean-reset': 'Clean Reset: Detox & Gifstoffen',
+    'clean-reset': 'Clean Reset',
     'powerfoods-superfood-specerij': 'PowerFoods: Superfood & Specerij™',
     'de-juiste-balans': 'De Juiste Balans: Energie & Hormonen',
     '30-dagen-challenge': '30 Dagen Challenge',
@@ -36,88 +36,13 @@
   };
 
   const cleanResetChapters = [
-    { start: 1, end: 5, title: 'Introductie' },
-    { start: 6, end: 10, title: 'Voeding' },
-    { start: 11, end: 15, title: 'Supplementen' },
-    { start: 16, end: 20, title: 'Leefstijl' },
-    { start: 21, end: 25, title: 'Reset & behoud' },
-    { start: 26, end: 30, title: 'BPA & ftalaten' },
-    { start: 31, end: 35, title: 'Parabenen & verzorging' },
-    { start: 36, end: 40, title: 'Leefstijl verdiept' },
-    { start: 41, end: 45, title: 'Voeding & supplementen' },
-    { start: 46, end: 51, title: 'Leefomgeving & afronding' }
+    { start: 1, end: 4, title: 'Regie zonder angst' },
+    { start: 5, end: 9, title: 'Stoffen begrijpen' },
+    { start: 10, end: 13, title: 'Keuken & drinkwater' },
+    { start: 14, end: 17, title: 'Huis & verzorging' },
+    { start: 18, end: 21, title: 'Je lichaam ondersteunen' },
+    { start: 22, end: 24, title: 'Jouw resetplan' }
   ];
-
-  const cleanResetSidebarTitles = {
-    3: 'Hoe toxines binnenkomen',
-    6: 'Jouw lichaam als detoxmachine',
-    7: 'De lever als detoxfabriek',
-    8: 'De nieren als filters',
-    9: 'De darmen als poortwachters',
-    12: 'Microplastics in je lichaam',
-    13: 'Microplastics & gezondheid',
-    14: 'Microplastics verminderen',
-    15: 'Microplastics afvoeren',
-    17: 'Waarom PFAS gevaarlijk zijn',
-    19: 'PFAS-blootstelling verminderen',
-    20: 'PFAS sneller kwijtraken',
-    21: 'Pesticiden in je voeding',
-    22: 'Biologisch: wat betekent het?',
-    23: 'Detox-boosters tegen pesticiden',
-    24: 'Pesticiden verminderen',
-    25: 'Regie over je voeding',
-    26: 'BPA & ftalaten',
-    28: 'BPA & ftalaten en hormonen',
-    29: 'BPA & ftalaten vermijden',
-    30: 'BPA & ftalaten kwijtraken',
-    31: 'Parabenen in cosmetica',
-    33: 'Parabenen & labels',
-    34: 'Cosmetica zonder parabenen',
-    36: 'Leefstijl als detox-sleutel',
-    37: 'Beweging & lymfesysteem',
-    39: 'Ademhaling & stress',
-    40: 'Ontspanning & detox',
-    41: 'Detox-voeding & supplementen',
-    44: 'Zwavelverbindingen & detox',
-    45: 'Supplementen voor detox',
-    46: 'Toxines in je leefomgeving',
-    48: 'Huisstof & toxines',
-    49: 'Schone huishoudproducten',
-    50: 'Maak je leefomgeving detox-proof'
-  };
-
-  const readerOverrides = {
-    'clean-reset:1': {
-      title: 'Welkom & intentie van de cursus',
-      lead: 'De fundering voor alles wat volgt — waarom je hier bent, wat Clean Reset je gaat brengen, en hoe je dit programma het beste benadert.',
-      duration_min: 12,
-      type: 'Introductie',
-      content_html: `
-        <p>Stel je voor: je lichaam is een huis waarin jij al je hele leven woont. Dag en nacht zorgt dat huis voor jou — het beschermt je, geeft je energie, herstelt zich telkens weer. Maar zonder dat je het doorhad, zijn er door de jaren heen kleine scheurtjes ontstaan. Niet omdat je iets verkeerd deed, maar omdat de wereld waarin we leven veranderde.</p>
-        <p>Je ademt lucht in die niet meer zo puur is als honderd jaar geleden. Je drinkt water waar onzichtbare deeltjes in zweven. Je eet voeding die bewerkt, bespoten of verpakt is. En zo bouwt dat huis, jouw lichaam, ongemerkt steeds meer bagage op.</p>
-        <p>Toxines. Stoffen waar je niet om hebt gevraagd. Stoffen die je niet ziet, maar die wel invloed hebben op hoe je je voelt, hoe je presteert, hoe je veroudert. Dat is precies waar deze cursus over gaat.</p>
-        <h2>Waarom jij hier bent</h2>
-        <p>Je bent hier omdat je diep van binnen voelt dat het anders kan. Misschien herken je het: vermoeid wakker worden terwijl je genoeg geslapen hebt. Last van concentratie-dips midden op de dag. Een hormonale disbalans die je lijf of gemoed onderuit haalt. Of gewoon het besef: ik leef gezond, maar tóch voel ik me niet optimaal.</p>
-        <blockquote><p>Dat is geen toeval. Het is het resultaat van die stille, onzichtbare belasting waar we allemaal mee te maken hebben.</p></blockquote>
-        <h2>Wat deze cursus je gaat brengen</h2>
-        <p>Clean Reset is geen hype, geen snelle detox-kuur waarbij je drie dagen op sap leeft. Het is een fundamenteel herstartpunt. Een manier om:</p>
-        <ul>
-          <li>Bewust te worden van de stoffen die je nu nog tegenhouden</li>
-          <li>Te leren hoe je lichaam van nature wil ontgiften — en hoe jij dat proces kunt ondersteunen</li>
-          <li>Praktisch aan de slag te gaan met voeding, supplementen en leefstijl</li>
-          <li>Slim keuzes te maken zodat je blootstelling drastisch afneemt</li>
-          <li>Een nieuwe standaard te creëren voor jezelf, die je de rest van je leven vooruit helpt</li>
-        </ul>
-        <blockquote><p>Dit is niet alleen een cursus die je informatie geeft — dit is een cursus die je transformatie geeft.</p></blockquote>
-        <h2>De intentie</h2>
-        <p>Mijn intentie met Clean Reset is helder: jou de regie teruggeven. Je lichaam kán meer dan je denkt, als je het de juiste omstandigheden geeft. Jij gaat ontdekken hoe krachtig een lichaam kan zijn dat minder toxische ballast hoeft te dragen.</p>
-        <p>Dat betekent meer energie. Meer focus. Een beter herstel. En misschien wel het belangrijkste: een gevoel van lichtheid, vrijheid in je lijf, omdat je weet dat je niet langer onbewust volloopt met stoffen die je helemaal niet nodig hebt.</p>
-        <h2>Jouw commitment</h2>
-        <p>Dit is jouw startpunt. Vanaf vandaag kies jij voor helderheid. Voor bewustzijn. Voor verandering die écht blijft hangen.</p>
-        <p>Zie deze cursus als een belofte aan jezelf: dat je niet genoegen neemt met "wel oké", maar dat je voor het beste gaat wat jouw lichaam je te bieden heeft.</p>
-        <blockquote><p>Welkom bij Clean Reset. Dit is het begin van jouw nieuwe standaard.</p></blockquote>`
-    }
-  };
 
   const state = {
     slug: null,
@@ -172,15 +97,25 @@
 
   function readCompleted() {
     const result = new Set();
-    try {
-      const stored = JSON.parse(localStorage.getItem('completedLessons') || '[]');
-      if (Array.isArray(stored)) stored.forEach((value) => result.add(String(value)));
-    } catch (error) {
-      // Keep the reader available when storage is blocked or malformed.
+    const contentVersion = Number(state.course?.content_version || 1);
+    const usesVersionedProgress = state.slug === 'clean-reset' && contentVersion >= 2;
+
+    if (!usesVersionedProgress) {
+      try {
+        const stored = JSON.parse(localStorage.getItem('completedLessons') || '[]');
+        if (Array.isArray(stored)) stored.forEach((value) => result.add(String(value)));
+      } catch (error) {
+        // Keep the reader available when storage is blocked or malformed.
+      }
     }
+
     state.lessons.forEach((lesson) => {
       try {
-        if (localStorage.getItem(`progress:${state.slug}:${lesson.id}:done`) === 'true') {
+        const versionedKey = `progress:${state.slug}:v${contentVersion}:${lesson.id}:done`;
+        const lessonKey = `progress:${state.slug}:${lesson.id}:done`;
+        const isDone = localStorage.getItem(usesVersionedProgress ? versionedKey : lessonKey) === 'true'
+          || (usesVersionedProgress && localStorage.getItem(lessonKey) === 'true');
+        if (isDone) {
           result.add(String(lesson.index));
           result.add(String(lesson.id));
         }
@@ -196,8 +131,7 @@
   }
 
   function lessonView(lesson) {
-    const override = readerOverrides[`${state.slug}:${lesson.index}`];
-    return override ? { ...lesson, ...override } : lesson;
+    return lesson;
   }
 
   function shortTitle(title) {
@@ -205,9 +139,6 @@
   }
 
   function sidebarTitle(lesson, view) {
-    if (state.slug === 'clean-reset' && cleanResetSidebarTitles[lesson.index]) {
-      return cleanResetSidebarTitles[lesson.index];
-    }
     return shortTitle(view.title);
   }
 
@@ -292,6 +223,94 @@
     return { lead, html: holder.innerHTML || '<p>De inhoud van deze les wordt binnenkort toegevoegd.</p>' };
   }
 
+  function renderParagraphs(paragraphs, className = '') {
+    return (paragraphs || []).map((paragraph) => `<p${className ? ` class="${className}"` : ''}>${escapeHTML(paragraph)}</p>`).join('');
+  }
+
+  function renderBullets(items, ordered = false) {
+    if (!Array.isArray(items) || !items.length) return '';
+    const tag = ordered ? 'ol' : 'ul';
+    return `<${tag} class="${ordered ? 'step-list' : 'flist'}">${items.map((item) => `<li>${escapeHTML(item)}</li>`).join('')}</${tag}>`;
+  }
+
+  function renderLessonImage(image) {
+    if (!image || !String(image.src || '').startsWith('/assets/')) return '';
+    return `
+      <figure class="course-figure">
+        <img src="${escapeHTML(image.src)}" alt="${escapeHTML(image.alt || '')}" loading="lazy" decoding="async">
+        ${image.caption ? `<figcaption>${escapeHTML(image.caption)}</figcaption>` : ''}
+      </figure>`;
+  }
+
+  function renderCallout(kind, text) {
+    if (!text) return '';
+    const labels = { note: 'Praktisch', warning: 'Let op' };
+    return `
+      <aside class="lesson-callout lesson-callout-${kind}">
+        <span class="callout-label">${labels[kind] || 'Notitie'}</span>
+        <p>${escapeHTML(text)}</p>
+      </aside>`;
+  }
+
+  function renderStructuredLesson(lesson) {
+    const imageAfterSection = Number(lesson.image?.after_section || 0);
+    const sections = (lesson.sections || []).map((section, index) => `
+      <section class="sec">
+        <div class="sec-eyebrow">Stap ${String(index + 1).padStart(2, '0')}</div>
+        <h2>${escapeHTML(section.title)}</h2>
+        ${renderParagraphs(section.paragraphs)}
+        ${renderBullets(section.bullets)}
+        ${renderCallout('note', section.note)}
+        ${renderCallout('warning', section.warning)}
+      </section>
+      ${lesson.image && imageAfterSection === index + 1 ? renderLessonImage(lesson.image) : ''}
+    `).join('');
+
+    const assignment = lesson.assignment ? `
+      <section class="lesson-action" aria-labelledby="lesson-action-title">
+        <div class="action-topline">
+          <span class="action-kicker">Jouw actie</span>
+          ${lesson.assignment.time ? `<span class="action-time">${escapeHTML(lesson.assignment.time)}</span>` : ''}
+        </div>
+        <h2 id="lesson-action-title">${escapeHTML(lesson.assignment.title)}</h2>
+        ${lesson.assignment.intro ? `<p>${escapeHTML(lesson.assignment.intro)}</p>` : ''}
+        ${renderBullets(lesson.assignment.steps, true)}
+        ${lesson.assignment.reflection ? `
+          <div class="reflection">
+            <span>Reflectievraag</span>
+            <p>${escapeHTML(lesson.assignment.reflection)}</p>
+          </div>` : ''}
+      </section>` : '';
+
+    const remember = Array.isArray(lesson.remember) && lesson.remember.length ? `
+      <section class="lesson-remember">
+        <div class="remember-kicker">Neem mee</div>
+        <h2>Onthoud dit</h2>
+        ${renderBullets(lesson.remember)}
+      </section>` : '';
+
+    const sources = Array.isArray(lesson.sources) && lesson.sources.length ? `
+      <section class="lesson-sources">
+        <h2>Betrouwbare verdieping</h2>
+        <p>Deze links brengen je naar de oorspronkelijke publieke informatie waarop deze les steunt.</p>
+        <ul>
+          ${lesson.sources.map((source) => `
+            <li><a href="${escapeHTML(source.url)}" target="_blank" rel="noopener noreferrer">${escapeHTML(source.label)}<span aria-hidden="true">↗</span></a></li>
+          `).join('')}
+        </ul>
+      </section>` : '';
+
+    return `
+      <div class="lesson-opening">
+        ${renderParagraphs(lesson.opening)}
+      </div>
+      ${lesson.image && imageAfterSection === 0 ? renderLessonImage(lesson.image) : ''}
+      ${sections}
+      ${assignment}
+      ${remember}
+      ${sources}`;
+  }
+
   function decorateContent(html) {
     const holder = document.createElement('div');
     holder.innerHTML = String(html || '').trim();
@@ -334,6 +353,7 @@
 
   function renderLesson() {
     const view = lessonView(state.current);
+    const isStructured = Array.isArray(view.sections) && view.sections.length > 0;
     const content = view.lead
       ? { lead: view.lead, html: view.content_html }
       : extractContent(state.current);
@@ -350,7 +370,9 @@
     $('#lessonTags').innerHTML = `
       <span class="tag tag-o">${escapeHTML(view.type || state.course.level || 'Theorie')}</span>
       <span class="tag tag-o">Hoofdstuk ${chapter}</span>`;
-    $('#lessonContent').innerHTML = decorateContent(content.html);
+    $('#lessonContent').innerHTML = isStructured
+      ? renderStructuredLesson(view)
+      : decorateContent(content.html);
   }
 
   function renderPage() {
@@ -438,7 +460,7 @@
     applyTheme(themes[state.slug], state.slug);
 
     try {
-      const response = await fetch(`/data/courses/${encodeURIComponent(state.slug)}.json?v=4`, { credentials: 'same-origin' });
+      const response = await fetch(`/data/courses/${encodeURIComponent(state.slug)}.json?v=5`, { credentials: 'same-origin' });
       if (!response.ok) throw new Error('course-not-found');
       state.course = await response.json();
       state.lessons = (state.course.lessons || []).filter((lesson) => !lesson.draft);

--- a/course-view.html
+++ b/course-view.html
@@ -47,7 +47,7 @@
   </script>
   <link rel="icon" type="image/webp" href="/assets/images/vitalora logo.webp">
   <link rel="stylesheet" href="/assets/css/fonts.css?v=5">
-  <link rel="stylesheet" href="/assets/css/course-reader.css?v=13">
+  <link rel="stylesheet" href="/assets/css/course-reader.css?v=14">
 </head>
 <body>
   <aside class="sidebar" aria-label="Cursusnavigatie">
@@ -107,6 +107,6 @@
     </div>
   </main>
 
-  <script src="/assets/js/course-view.js?v=9" defer></script>
+  <script src="/assets/js/course-view.js?v=10" defer></script>
 </body>
 </html>

--- a/data/courses/clean-reset.json
+++ b/data/courses/clean-reset.json
@@ -1,473 +1,1493 @@
 {
   "slug": "clean-reset",
-  "title": "Clean Reset",
-  "subtitle": "Detox en gifstoffen",
-  "level": "Intensief",
+  "content_version": 2,
+  "title": "Clean Reset — Minder toxische belasting, meer regie",
+  "subtitle": "Een warme, nuchtere 28-daagse leerreis door PFAS, microplastics, bisfenolen en slimme dagelijkse keuzes.",
+  "level": "Praktisch programma",
+  "duration_days": 28,
   "theme": {
-    "grad_a": "#0ea5e9",
-    "grad_b": "#1d4ed8",
-    "brand": "#2563eb"
+    "grad_a": "#3a9aea",
+    "grad_b": "#2563eb",
+    "brand": "#3a9aea"
   },
-  "duration_days": 21,
   "lessons": [
     {
-      "id": "les-1-microplastics",
+      "id": "cr2-les-01-welkom",
       "index": 1,
-      "title": "Les 1: De eerste stap in jouw detoxreis",
-      "type": "Theorie",
-      "duration_min": 15,
+      "title": "Welkom: jouw reset begint hier",
+      "type": "Start",
+      "duration_min": 8,
       "draft": false,
-      "content_html": "<h2>🌱 Les 1</h2>\n<h3>De eerste stap in jouw detoxreis</h3>\n\n<p>Toen ik jaren geleden voor het eerst hoorde dat wetenschappers microplastics hadden gevonden in het bloed van mensen, raakte dat me diep. Niet omdat ik dacht: oh jee, de wereld gaat vergaan, maar omdat ik me realiseerde dat dit ook ín mij zat. En in mijn kinderen. Dat besef zette alles op scherp. Want hoe kun je gezond leven, als je elke dag ongemerkt volloopt met stoffen die je lichaam eigenlijk helemaal niet kent?</p>\n\n<p>Detoxen klonk voor mij altijd een beetje vaag. Een hype. Een juice cleanse van drie dagen en klaar. Maar dat is niet waar het om draait. Je lichaam is zelf al een geniale detoxmachine. Je lever, je nieren, je huid, je darmen – ze werken dag en nacht voor je. Alleen… ze krijgen tegenwoordig véél meer te verduren dan vroeger. Denk aan PFAS in ons drinkwater, pesticiden op fruit, parabenen in shampoo, BPA in plastic. Het stapelt zich op. En precies daar gaat deze reis over: leren hoe je die last vermindert, en je lichaam weer de ruimte geeft om te doen waar het voor gemaakt is.</p>\n\n<p>Misschien herken je dit: altijd een beetje moe. Vage huidproblemen. Hormonen die uit balans lijken. Slechte slaap. Ik dacht vroeger dat dat er gewoon \"bij hoorde\". Tot ik besefte dat mijn lichaam niet lui was, maar overbelast. Dat inzicht veranderde mijn hele manier van leven.</p>\n\n<p>Daarom wil ik dat je dit avontuur ook persoonlijk maakt. Neem een notitieboekje of je telefoon erbij en schrijf drie dingen op:</p>\n\n<ul>\n<li>Waarom je hier bent.</li>\n<li>Wat je nu al voelt in je lichaam waar je verandering in wilt.</li>\n<li>Hoe jij je het liefst zou willen voelen drie maanden vanaf nu.</li>\n</ul>\n\n<p>Dat lijkt simpel, maar geloof me: dit is je ankerpunt. Dit is de plek waar je straks op terug kunt kijken en denkt: wauw, kijk eens wat er veranderd is.</p>\n\n<p>Dit programma wordt geen droge studie vol feitjes. Het is een reis. Mijn verhaal loopt erin mee, en jij schrijft ondertussen jouw eigen hoofdstuk. En als je denkt dat toxines vooral in plastic flesjes of fastfood zitten, wacht maar tot je ziet hóe diep ze verweven zijn in ons dagelijks leven. Dat is waar we zo in gaan duiken.</p>"
+      "lead": "Je hoeft niet perfect te leven om verschil te maken. Deze reis helpt je rustig kiezen waar minder blootstelling haalbaar én zinvol is.",
+      "opening": [
+        "Misschien begon je aan deze cursus met een onrustig gevoel. Je leest over PFAS in water, microplastics in bloed en stoffen in verpakkingen waarvan je de naam nauwelijks kunt uitspreken. Dan lijkt het al snel alsof alles fout is. Dat gevoel nemen we serieus, maar we laten het niet de leiding nemen.",
+        "Clean Reset is geen sapkuur en geen belofte dat één product je lichaam ‘schoonmaakt’. Je lever, nieren, darmen, longen en huid werken iedere dag voor je. Onze opdracht is eenvoudiger en eerlijker: vermijdbare blootstelling stap voor stap verkleinen, gezonde basisgewoonten ondersteunen en leren omgaan met wat je niet volledig kunt controleren."
+      ],
+      "sections": [
+        {
+          "title": "Wat je hier wél gaat bereiken",
+          "paragraphs": [
+            "Na vier weken herken je belangrijke bronnen in je eigen huis, kun je claims op verpakkingen beter beoordelen en heb je een persoonlijk plan dat niet afhankelijk is van motivatie of dure aankopen. Je leert prioriteren: eerst de keuzes die vaak terugkomen, dicht bij je staan en weinig moeite kosten.",
+            "Je zult ook merken dat goede keuzes zelden zwart-wit zijn. Glas is handig, maar een glazen voorraadkast vol nieuwe spullen is niet verplicht. Biologisch kan een bewuste keuze zijn, maar gewone groente en fruit blijven waardevol. Een filter kan in een specifieke situatie helpen, maar alleen wanneer je weet wat het verwijdert en het goed onderhoudt."
+          ],
+          "bullets": [
+            "Begrijpen wat risico werkelijk betekent: stof, dosis, route, frequentie en duur.",
+            "Dagelijkse bronnen herkennen zonder je huis als een gevaarlijke plek te zien.",
+            "Een haalbare vervangladder maken: nu stoppen, later vervangen of bewust behouden.",
+            "Gezondheidsclaims onderscheiden van feiten, aannames en marketing."
+          ]
+        },
+        {
+          "title": "Jouw tempo is onderdeel van het plan",
+          "paragraphs": [
+            "Volg bij voorkeur één les per dag en gebruik de rustdagen om iets uit te proberen. Sommige lessen zijn kennislessen; andere brengen je letterlijk naar je keuken, badkamer of voorraadkast. Een kleine actie die blijft, is meer waard dan een grote opruiming die je volgende week alweer moe maakt.",
+            "Bewaar één notitie met drie kopjes: ontdekt, besloten en later. Zo hoeft niet iedere ontdekking direct een aankoop of verbod te worden. Je traint regie, niet controle."
+          ],
+          "note": "Je hoeft tijdens deze cursus niets weg te gooien dat nog goed functioneert. Veilig gebruiken en pas bij een logisch vervangmoment kiezen is vaak de duurzaamste route."
+        },
+        {
+          "title": "Eerst veiligheid",
+          "paragraphs": [
+            "Deze cursus is algemene educatie en vervangt geen diagnose of behandeling. Bespreek ingrijpende voedingsveranderingen, vasten of supplementen eerst met een arts of apotheker als je zwanger bent, borstvoeding geeft, medicatie gebruikt, een eetstoornis hebt of een aandoening van lever of nieren hebt.",
+            "Werk je beroepsmatig met blusschuim, oplosmiddelen, stof, coatings, pesticiden of andere chemicaliën? Dan zijn persoonlijke leefstijltips niet genoeg. Volg de veiligheidsinstructies op je werk en bespreek mogelijke blootstelling met de bedrijfsarts of arbodienst. Bij acute blootstelling of klachten zoek je medische hulp."
+          ],
+          "warning": "Gebruik nooit chelatiemiddelen, hoge doseringen supplementen of extreme vastenprotocollen om PFAS, microplastics of andere stoffen ‘uit je lichaam te trekken’. Daarvoor is geen veilige zelfzorgbasis."
+        }
+      ],
+      "assignment": {
+        "title": "Schrijf jouw rustige startzin",
+        "time": "10 minuten",
+        "intro": "Open je notitie en maak deze cursus persoonlijk zonder jezelf een onmogelijke belofte te doen.",
+        "steps": [
+          "Schrijf waarom je minder toxische belasting belangrijk vindt.",
+          "Kies één gevoel dat je tijdens de cursus wilt oefenen, bijvoorbeeld rust, nieuwsgierigheid of regie.",
+          "Maak de zin af: ‘Na 28 dagen wil ik drie keuzes kennen die bij mijn leven passen, namelijk …’",
+          "Plan twee vaste momenten per week van twintig minuten voor de praktische opdrachten."
+        ],
+        "reflection": "Wat zou voor jou een geslaagde cursus zijn, ook als je niets spectaculairs aan je lichaam voelt?"
+      },
+      "remember": [
+        "Clean Reset draait om blootstelling verminderen, niet om een wonderkuur.",
+        "Regie is haalbare keuzes maken, niet alle onzekerheid uitbannen.",
+        "Medische of beroepsmatige blootstelling vraagt professionele begeleiding."
+      ]
     },
     {
-      "id": "les-2-omgeving",
+      "id": "cr2-les-02-blootstellingskaart",
       "index": 2,
-      "title": "Les 2: Wat toxines écht zijn",
-      "type": "Theorie",
-      "duration_min": 12,
+      "title": "Maak je blootstellingskaart",
+      "type": "Praktijk",
+      "duration_min": 8,
       "draft": false,
-      "content_html": "<h2>🌱 Les 2</h2>\n<h3>Wat toxines écht zijn</h3>\n\n<p>Ik herinner me nog goed dat ik ooit in de supermarkt stond met een bakje aardbeien in mijn hand. Stralend rood, glanzend, bijna té perfect. En ineens dacht ik: hoeveel lagen gif zitten hier eigenlijk op? Het klonk bijna paranoïde, maar later ontdekte ik dat ik er helemaal niet zo ver naast zat. Want wat zijn die stoffen nou eigenlijk, die ons lichaam binnendringen zonder dat we het doorhebben?</p>\n\n<p>Toxines zijn simpel gezegd indringers. Stoffen die jouw lichaam niet nodig heeft, en die soms zelfs regelrecht tegen je werken. Je immuunsysteem, je hormonen, je energieniveau – allemaal kunnen ze verstoord raken door deze onzichtbare bezoekers. En dat is misschien wel het verraderlijke: vaak voel je niet meteen dat ze er zijn. Het stapelt zich langzaam op.</p>\n\n<p>Kijk, een keer friet eten of een keer een plastic flesje gebruiken is niet het probleem. Je lichaam is sterk genoeg om dat op te vangen. Het probleem zit 'm in dagelijkse blootstelling. Elke dag een beetje. Inademen, inslikken, opsmeren, aanraken. Het gaat niet om die ene druppel, maar om de emmer die langzaam volloopt.</p>\n\n<p>Daarom maken wetenschappers zich zorgen. Ze vinden microplastics in het bloed, PFAS in moedermelk, parabenen in borstweefsel. En nee, dat is geen bangmakerij. Het is de realiteit waarin we leven. Het goede nieuws? Zodra je weet wát toxines zijn en hoe ze je leven binnensluipen, kun je keuzes maken die je lichaam direct lucht geven.</p>\n\n<p>Om je alvast nieuwsgierig te maken: toxines zitten niet alleen in eten of plastic verpakkingen. Ze zitten ook in kassabonnetjes, je favoriete parfum, je pannen, je kleding, zelfs in het stof op je nachtkastje. De kans is groot dat je vandaag al tientallen keren onbewust in aanraking bent gekomen.</p>\n\n<p>Sta daarom eens even stil bij jouw eigen dag. Denk terug: wat heb je gegeten, gedronken, aangeraakt, ingesmeerd? Schrijf drie momenten op waarvan je vermoedt: hé, dit zou best een bron van toxines kunnen zijn. Het hoeft niet perfect te kloppen – dit gaat puur om bewustwording.</p>\n\n<p>Want hier begint jouw detoxreis echt: bij het zien van wat je eerst niet zag.</p>\n\n<p>En geloof me: als je denkt dat dit al veel is, wacht maar tot we kijken hóe slim toxines ons leven binnensluipen. Dat is de volgende eye-opener.</p>"
+      "lead": "Niet een algemene lijst op internet, maar jouw gewone dinsdag vertelt waar de slimste winst te vinden is.",
+      "opening": [
+        "Blootstelling klinkt technisch, maar begint met een eenvoudige vraag: wanneer komt een stof bij jou in de buurt? Dat kan via eten en drinken, via de lucht en huisstof, via huidcontact of door werk en hobby’s. De ene route is relevanter dan de andere, afhankelijk van de stof en jouw gewoonten.",
+        "Vandaag ga je nog niets oplossen. Je brengt alleen je dag in kaart. Dat voorkomt dat je straks geld en energie steekt in een zeldzaam product terwijl een dagelijkse gewoonte onbesproken blijft."
+      ],
+      "sections": [
+        {
+          "title": "Volg een dag van ochtend tot avond",
+          "paragraphs": [
+            "Loop in gedachten door je vaste ritme. Waar bewaar of verwarm je eten? Uit welke fles drink je? Welke verzorgingsproducten gebruik je? Ventileer je bij koken en douchen? Werk je in stof, verf, olie, textiel of schoonmaakmiddelen? Noteer situaties, geen schuld.",
+            "Een bron is nog geen bewezen gezondheidsprobleem. Een plastic broodtrommel die je koud gebruikt is een andere situatie dan beschadigd plastic waarin je dagelijks vet eten verhit. Context maakt het verschil."
+          ],
+          "bullets": [
+            "Inslikken: voeding, water, stof op handen en materialen die met eten in contact komen.",
+            "Inademen: huisstof, kookdampen, verkeer, sprays en vezels uit slijtage.",
+            "Huidcontact: cosmetica, schoonmaakmiddelen en materialen die lang op de huid zitten.",
+            "Werk of hobby: terugkerend contact met specifieke stoffen of hoge concentraties."
+          ]
+        },
+        {
+          "title": "Geef elke situatie drie kenmerken",
+          "paragraphs": [
+            "Schrijf bij iedere mogelijke bron hoe vaak die voorkomt, hoe direct het contact is en hoe makkelijk je de situatie kunt aanpassen. Dagelijks, direct en eenvoudig krijgt voorrang. Zelden, indirect en moeilijk mag voorlopig naar de achtergrond.",
+            "Voorbeeld: elke dag heet eten meenemen in een oud kunststof bakje scoort hoog op frequentie en direct contact. Een regenjas met onbekende coating die je twee keer per jaar draagt, scoort lager. Je hoeft niet exact te weten welke chemische stof aanwezig is om rationeel te prioriteren."
+          ],
+          "note": "Een blootstellingskaart is een beslisdocument, geen inventaris van alles wat mogelijk gevaarlijk zou kunnen zijn."
+        },
+        {
+          "title": "Kijk ook naar wat al goed gaat",
+          "paragraphs": [
+            "Misschien ventileer je al tijdens het koken, gebruik je glas voor restjes of koop je weinig geparfumeerde sprays. Zet die beschermende gewoonten expliciet op de kaart. Dat maakt zichtbaar dat je niet bij nul begint en voorkomt een alles-of-nietsgevoel.",
+            "Je kaart is vandaag een eerste versie. In latere lessen voeg je kennis toe en schrap je vermoedens die niet relevant blijken. Zo hoort leren te werken: niet steeds banger worden, maar steeds beter kiezen."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "De 24-uurs scan",
+        "time": "15 minuten",
+        "intro": "Maak vier kolommen: eten en drinken, lucht en stof, huid en verzorging, werk en hobby.",
+        "steps": [
+          "Noteer per kolom maximaal vijf terugkerende situaties.",
+          "Zet een ster bij alles wat dagelijks of bijna dagelijks gebeurt.",
+          "Omcirkel situaties die je zonder aankoop kunt aanpassen.",
+          "Markeer ook drie gewoonten die je al wilt behouden."
+        ],
+        "reflection": "Welke bron verraste je, en welke bleek minder belangrijk dan je vooraf dacht?"
+      },
+      "remember": [
+        "Frequentie en direct contact helpen je prioriteren.",
+        "Een mogelijke bron is niet automatisch een gezondheidsrisico.",
+        "Beschermende gewoonten horen ook op je kaart."
+      ]
     },
     {
-      "id": "les-3-problemen",
+      "id": "cr2-les-03-risico",
       "index": 3,
-      "title": "Les 3: Hoe toxines ongemerkt ons leven binnensluipen",
-      "type": "Theorie",
-      "duration_min": 14,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 3</h2>\n<h3>Hoe toxines ongemerkt ons leven binnensluipen</h3>\n\n<p>Toen ik mijn keuken eens kritisch bekeek, schrok ik van mezelf. Ik dacht altijd: \"Ik eet gezond, ik koop biologisch, ik doe het goed.\" Maar toen ik ontdekte dat de anti-aanbaklaag van mijn favoriete pan vol PFAS zat, voelde ik me belazerd. Ik had er letterlijk dagelijks mijn eten in bereid. Precies dit is de valstrik van toxines: ze zitten vaak in de plekken waar je ze het minst verwacht.</p>\n\n<p>We denken snel aan plastic flesjes of fastfood – en ja, dat klopt ook – maar de echte verrassing zit 'm in de details. Een paar voorbeelden die bijna iedereen dagelijks tegenkomt:</p>\n\n<h4>Je kleding</h4>\n<p>Veel sportkleding en regenjassen bevatten PFAS, zodat ze \"waterdicht\" zijn. Elke keer dat je zweet, geef je die stoffen de kans om via je huid binnen te dringen.</p>\n\n<h4>Je kassabon</h4>\n<p>Het papier waarmee je boodschappen afrekent bevat BPA, een hormoonverstorende stof. Een paar seconden vasthouden is genoeg om via je huid opgenomen te worden.</p>\n\n<h4>Je lucht</h4>\n<p>Huisstof zit vol microplastics en weekmakers van meubels, vloerkleden en elektronica. Elke ademhaling is een klein beetje extra belasting.</p>\n\n<h4>Je badkamer</h4>\n<p>Shampoo, deodorant, parfum – vaak vol parabenen en ftalaten die je hormoonbalans subtiel onderuit halen.</p>\n\n<h4>Je voeding</h4>\n<p>Pesticiden blijven achter, ook al spoel je groente en fruit af. En die \"gezonde\" yoghurt uit plastic beker? Soms komt er microplastic mee in je eten.</p>\n\n<p>Zie je wat er gebeurt? Het gaat niet om dat ene product. Het gaat om de optelsom. Tientallen kleine beetjes per dag die samen een flinke belasting worden voor je lichaam.</p>\n\n<p>En hier zit de kracht van bewustwording: zodra je ze begint te herkennen, kun je ook keuzes maken. Want je hoeft niet in angst te leven. Je hoeft niet alles tegelijk perfect te doen. Maar elke bron die je vermindert, is een last minder voor je lijf.</p>\n\n<p>Ik weet nog dat ik begon met iets simpels: mijn plastic waterfles vervangen door een glazen fles. Het voelde bijna te klein om impact te hebben, maar dat ene kleine stapje gaf me het gevoel: hé, ik heb invloed. En precies dat gevoel wil ik dat jij ook gaat ervaren.</p>\n\n<p>Pak vandaag je notitieboekje erbij en kies één bron van toxines waarvan jij denkt: die kan ik makkelijk vervangen of vermijden. Misschien je waterfles, misschien je schoonmaakmiddel, misschien je deo. Begin klein. Maar begin.</p>\n\n<p>Want zodra je dat eerste bewuste besluit neemt, voel je dat jij de regie hebt. En geloof me: dat is pas het begin.</p>"
-    },
-    {
-      "id": "les-4-praktische-tips",
-      "index": 4,
-      "title": "Les 4: Wat toxines met je lichaam doen",
-      "type": "Praktijk",
-      "duration_min": 18,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 4</h2>\n<h3>Wat toxines met je lichaam doen</h3>\n\n<p>Er was een periode dat ik mezelf afvroeg: \"Waarom voel ik me zo vaak moe, terwijl ik toch gezond leef?\" Ik sportte, ik at mijn groentes, ik sliep genoeg. En toch… mijn energie was niet stabiel, mijn huid was onrustig en mijn hormonen deden rare dingen. Pas toen ik begreep hoe toxines inwerken op ons lichaam, vielen de puzzelstukjes op hun plek.</p>\n\n<p>Je lichaam is briljant ontworpen. Het wil maar één ding: in balans blijven. Maar toxines gooien zand in de motor. Niet met één grote klap, maar beetje bij beetje.</p>\n\n<p>Dit zijn een paar manieren waarop dat gebeurt:</p>\n\n<h4>Immuunsysteem</h4>\n<p>Je afweer werkt als een alarmsysteem. Toxines zorgen ervoor dat het vaak \"aan\" gaat, zelfs zonder directe dreiging. Het gevolg? Chronische ontstekingen, vermoeidheid, en een systeem dat minder alert is wanneer het écht nodig is.</p>\n\n<h4>Hormonen</h4>\n<p>Veel stoffen zoals BPA, ftalaten en parabenen bootsen hormonen na. Ze binden zich aan je receptoren alsof ze het echte werk zijn. Gevolg: verstoorde menstruatiecycli, verminderde vruchtbaarheid, dalend testosteron, stemmingswisselingen.</p>\n\n<h4>Energiehuishouding</h4>\n<p>Je mitochondriën – de energiecentrales van je cellen – raken overbelast door de voortdurende aanwezigheid van gifstoffen. Resultaat: je voelt je loom, sloom of opgebrand, zelfs al eet je gezond.</p>\n\n<h4>Hersenen</h4>\n<p>Sommige toxines, zoals zware metalen en microplastics, passen de bloed-hersenbarrière. Ze beïnvloeden je concentratie, geheugen en zelfs je stemming.</p>\n\n<h4>Darmen</h4>\n<p>Je microbioom – de miljarden bacteriën in je darmen – raakt uit balans. En omdat je darmen ook de basis zijn voor je immuunsysteem én hormonen, merk je dat op veel vlakken.</p>\n\n<p>Wat ik zelf heel confronterend vond: je merkt dit vaak pas laat. Toxines werken sluipend. Het is niet alsof je na één dag shampoo ineens ziek bent. Het zijn die kleine beetjes die langzaam je vitaliteit ondermijnen.</p>\n\n<p>Maar er is ook een andere kant. Zodra je begint te ontgiften en bronnen van toxines te verminderen, zie je vaak verrassend snel resultaat. Ik heb mensen gezien die na drie weken minder huiduitslag hadden. Zelf merkte ik dat mijn energie stabieler werd, en dat ik me mentaal helderder voelde.</p>\n\n<p>Denk nu eens na: welke van deze effecten herken jij het meest? Schrijf het op. Misschien is het je energie, misschien je hormonen, misschien je huid. Het is waardevol om dit vast te leggen – want straks ga je zien wat er verandert.</p>\n\n<p>En geloof me: de puzzel is nog niet compleet. Want de vraag die vaak boven komt is: hoe komt dit allemaal eigenlijk in mijn lichaam terecht? Precies daar gaan we in de volgende les naar kijken.</p>"
-    },
-    {
-      "id": "les-5",
-      "index": 5,
-      "title": "Les 5: Je eigen beginpunt vastleggen",
-      "type": "Praktijk",
-      "duration_min": 15,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 5</h2>\n<h3>Je eigen beginpunt vastleggen</h3>\n\n<p>Ik heb ooit maandenlang mijn voeding, slaap en energie bijgehouden. In het begin voelde het een beetje overdreven, bijna neurotisch. Maar wat er gebeurde, was magisch: ineens zag ik patronen die ik nooit eerder had opgemerkt. En het mooiste? Toen ik bewuster begon te leven, kon ik zwart op wit zien dat mijn lichaam écht veranderde.</p>\n\n<p>Daarom is het belangrijk dat jij nu ook je eigen startpunt vastlegt. Want detoxen is niet alleen een verhaal dat je leest – het is een transformatie die je gaat ervaren. En hoe beter je je begin kent, hoe meer voldoening je straks voelt als je terugkijkt.</p>\n\n<p>Dit zijn drie simpele manieren om vandaag te beginnen:</p>\n\n<h4>Energiecheck</h4>\n<p>Geef je dagelijkse energie een cijfer van 1–10. Hoe voel je je 's ochtends? Hoe zit je er halverwege de dag bij? En hoe eindig je je dag? Schrijf dit een paar dagen achter elkaar op.</p>\n\n<h4>Klachtenlijstje</h4>\n<p>Noteer alle signalen van je lichaam die je de laatste weken hebt ervaren. Denk aan: vermoeidheid, hoofdpijn, huidproblemen, hormonale klachten, concentratieproblemen, slechte slaap. Het hoeft niet medisch perfect te zijn – dit is puur jouw beeld van hoe je je voelt.</p>\n\n<h4>Dagboekje starten</h4>\n<p>Pak een schriftje of een digitaal document en schrijf kort op: \"Zo voel ik me vandaag. Dit wil ik bereiken.\" Maak er een kleine gewoonte van. Je zult versteld staan hoe waardevol dit straks is als je veranderingen ziet.</p>\n\n<p>Weet je wat het mooie is? Dit hoeft geen uren te kosten. Vijf minuten per dag is genoeg. Het gaat niet om perfecte data, maar om bewustwording.</p>\n\n<p>En geloof me: over een paar weken kijk je terug en denk je: \"Wauw, dit verschil had ik niet eens door als ik het niet had opgeschreven.\"</p>\n\n<p>Met deze stap sluit je de eerste fase van je reis af. Je hebt nu je \"waarom\", je begrijpt wat toxines zijn, je ziet hoe ze binnenkomen, je weet wat ze met je doen én je hebt je eigen nulmeting. Dat is een stevige fundering.</p>\n\n<p>Vanaf hier gaan we dieper. Want in het volgende hoofdstuk ontdek je hoe je lichaam zelf al is uitgerust met een geniaal detoxsysteem – en hoe jij dat systeem kunt versterken in plaats van belasten.</p>"
-    },
-    {
-      "id": "les-6",
-      "index": 6,
-      "title": "Les 6: Jouw lichaam: een natuurlijke detoxmachine",
-      "type": "Praktijk",
-      "duration_min": 16,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 6</h2>\n<h3>Jouw lichaam: een natuurlijke detoxmachine</h3>\n\n<p>Weet je wat mij altijd fascineert? Je lichaam is niet ontworpen om perfect schoon te blijven. Het is ontworpen om elke dag opnieuw de troep die je binnenkrijgt weer weg te werken. Het is eigenlijk een zelfreinigend systeem – slimmer dan elke kuur, pil of behandeling die je ooit zult tegenkomen.</p>\n\n<p>Denk er eens over na: elke dag adem je vervuilde lucht in, elke dag krijg je chemische restjes uit voeding binnen, elke dag smeer je iets op je huid dat er niet thuishoort. En tóch word je niet meteen ziek. Waarom? Omdat je lichaam 24/7 bezig is met opruimen.</p>\n\n<p>Je lever werkt als de chemische fabriek die gifstoffen neutraliseert en klaarmaakt om uit te scheiden.</p>\n\n<p>Je nieren filteren continu je bloed en voeren afvalstoffen af via je urine.</p>\n\n<p>Je darmen zorgen ervoor dat giftige stoffen en slechte bacteriën niet zomaar je systeem in glippen.</p>\n\n<p>Je huid is je grootste orgaan en voert via zweten letterlijk afvalstoffen uit.</p>\n\n<p>Zelfs je longen helpen door vervuiling en stof weer naar buiten te duwen.</p>\n\n<p>Het klinkt misschien alsof je lichaam alles wel aankan. En een deel klopt ook: dit systeem is briljant. Maar hier zit de crux: het is niet gebouwd voor de wereld waarin we nu leven.</p>\n\n<p>50 jaar geleden had je een appel met misschien wat pesticiden. Vandaag krijg je microplastics, PFAS, weekmakers, parabenen én pesticiden – allemaal tegelijk. En dat elke dag. Het is alsof je een prullenbak hebt die bedoeld was voor één huishouden, maar waar nu een heel flatgebouw zijn afval in dumpt. Op een gegeven moment loopt die prullenbak over.</p>\n\n<p>En dat is precies wat er gebeurt: je lever, je darmen, je nieren, je huid – ze werken zich kapot. Maar de toevoer van toxines is groter dan de capaciteit om ze af te voeren. En daar begint de opstapeling.</p>\n\n<p>Wat mij enorm geruststelde toen ik dit besefte: je hoeft je lichaam niet te \"fixen\". Je hoeft het alleen maar te helpen. Ontlasten waar je kunt, ondersteunen waar het vastloopt, en versterken wat al goed werkt. Dat is detoxen in de kern.</p>\n\n<p>Sta even stil bij deze vraag: welk onderdeel van jouw natuurlijke detoxmachine zou jij het liefst meer willen ondersteunen? Je energie (lever/mitochondriën)? Je huid? Je darmen? Je slaap? Schrijf het kort op. Het is interessant om te zien hoe dit zich ontwikkelt tijdens je reis.</p>\n\n<p>Want vanaf de volgende les duiken we per orgaan dieper in. Je gaat ontdekken hoe elk onderdeel van jouw lichaam zijn rol speelt in detox – en hoe jij dat orgaan kunt versterken, zodat je systeem weer ruimte krijgt.</p>"
-    },
-    {
-      "id": "les-7",
-      "index": 7,
-      "title": "Les 7: De lever: jouw persoonlijke detoxfabriek",
-      "type": "Theorie",
-      "duration_min": 14,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 7</h2>\n<h3>De lever: jouw persoonlijke detoxfabriek</h3>\n\n<p>Als er één orgaan is dat je letterlijk je leven lang beschermt tegen gifstoffen, dan is het je lever. Ik noem het vaak de CEO van detox. Alles wat jij eet, drinkt, inslikt, smeert of zelfs inademt, komt uiteindelijk bij je lever terecht. Het is de plek waar toxines onschadelijk worden gemaakt en klaargezet om je lichaam weer te verlaten.</p>\n\n<p>Stel je de lever voor als een gigantische fabriek. Bloed stroomt binnen als een vrachtwagen vol grondstoffen – maar ook met troep, chemische restjes en afval. De lever sorteert alles: wat bruikbaar is, mag door; wat gevaarlijk is, wordt geneutraliseerd. Pas daarna gaat het bloed weer verder je lichaam in.</p>\n\n<p>Dit orgaan werkt in twee fasen:</p>\n\n<p><strong>Fase 1:</strong> de lever breekt stoffen af tot kleinere stukjes. Handig, maar die stukjes zijn vaak nog giftiger dan de stof zelf.</p>\n\n<p><strong>Fase 2:</strong> hier worden die restproducten gebonden aan andere stoffen (zoals aminozuren of zwavelverbindingen), zodat ze veilig via urine of gal kunnen worden uitgescheiden.</p>\n\n<p>En precies hier gaat het vaak mis in onze moderne wereld. Want fase 1 draait overuren – er komen steeds nieuwe gifstoffen binnen – maar fase 2 kan het tempo niet bijhouden. Gevolg: toxines blijven in je lichaam circuleren en richten schade aan.</p>\n\n<p>Toen ik dit zelf begreep, werd me duidelijk waarom ik ondanks \"gezond eten\" toch klachten had. Mijn lever deed zijn best, maar ik gaf hem simpelweg te weinig bouwstenen om fase 2 goed te laten draaien.</p>\n\n<p>Gelukkig kun je je lever op eenvoudige manieren ondersteunen:</p>\n\n<ul>\n<li><strong>Voldoende eiwitten</strong> → aminozuren zijn nodig in fase 2.</li>\n<li><strong>Groene groenten</strong> zoals broccoli, spruitjes en boerenkool → bevatten zwavelverbindingen die helpen bij ontgifting.</li>\n<li><strong>Kruiden</strong> zoals kurkuma en mariadistel → ondersteunen levercellen.</li>\n<li><strong>Vermijd alcohol en overmatig medicijngebruik</strong> → beide leggen een zware last op je lever.</li>\n</ul>\n\n<p>Een kleine oefening voor jou: kijk eens naar je eetpatroon van de afgelopen week. Hoeveel écht groene groenten zaten erin? Zou je één maaltijd per dag kunnen upgraden met iets uit die categorie?</p>\n\n<p>Je lever is geen machine die je zomaar kunt vervangen. Het is een orgaan dat je de rest van je leven bij je draagt en dat nu al keihard voor je werkt. Hoe beter je hem voedt en beschermt, hoe meer ruimte hij krijgt om jouw lichaam schoon en energiek te houden.</p>\n\n<p>En dit is nog maar één stukje van de puzzel. In de volgende les gaan we kijken naar je nieren – de filters die elke dag 150 liter bloed doorspoelen en cruciaal zijn in het afvoeren van afvalstoffen.</p>"
-    },
-    {
-      "id": "les-8",
-      "index": 8,
-      "title": "Les 8: De nieren: jouw filters die nooit uitstaan",
-      "type": "Praktijk",
-      "duration_min": 17,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 8</h2>\n<h3>De nieren: jouw filters die nooit uitstaan</h3>\n\n<p>Ik kan me nog herinneren dat ik een keer enorm veel vocht vasthield. Mijn enkels waren dik, mijn gezicht opgeblazen. Ik dacht eerst dat ik gewoon zout had gegeten, maar eigenlijk probeerden mijn nieren me iets te vertellen. Ze waren overbelast.</p>\n\n<p>Je nieren zijn twee kleine boonvormige organen, maar hun taak is gigantisch. Elke dag filteren ze meer dan 150 liter bloed. Alles wat jouw lichaam niet nodig heeft – afvalstoffen, overtollig zout, water, chemische resten – wordt via je urine afgevoerd. Als je nieren dit niet zouden doen, zou je lichaam letterlijk binnen een paar dagen vergiftigd raken.</p>\n\n<p>Maar net zoals bij je lever, krijgen je nieren tegenwoordig meer te verduren dan ooit. Denk aan:</p>\n\n<ul>\n<li>Medicijnresten (zelfs veelgebruikte pijnstillers leggen druk op je nieren).</li>\n<li>PFAS en zware metalen uit drinkwater.</li>\n<li>Overmatig zout en bewerkt voedsel.</li>\n<li>Te weinig vocht → je bloed wordt dikker, waardoor je nieren harder moeten werken.</li>\n</ul>\n\n<p>Wat ik zelf heel verhelderend vond, is dat nieren stil kunnen lijden. Je voelt het vaak niet meteen als ze overbelast zijn. Pas als je last krijgt van vermoeidheid, vocht vasthouden of donkere kringen onder je ogen, kan dat een signaal zijn dat je nieren moeite hebben met hun werk.</p>\n\n<p>Gelukkig kun je ze eenvoudig ondersteunen:</p>\n\n<ul>\n<li><strong>Drink voldoende water</strong>, maar verspreid dit over de dag. Grote hoeveelheden in één keer belasten juist.</li>\n<li><strong>Vermijd frisdrank en energydrinks</strong> – die vragen meer van je nieren dan ze geven.</li>\n<li><strong>Kaliumrijke voeding</strong> zoals bananen, avocado en spinazie helpt de balans tussen zout en vocht.</li>\n<li><strong>Kruiden</strong> zoals peterselie en brandnetelthee staan bekend om hun nierondersteunende werking.</li>\n</ul>\n\n<p>Een kleine check-in voor jou: hoe vaak op een dag drink je écht water (dus geen koffie of fris)? Schrijf het voor jezelf op. Vaak denken we dat we genoeg drinken, maar zit het in werkelijkheid tegen de 1 of 2 glazen.</p>\n\n<p>Je nieren zijn stille werkers. Ze praten niet veel, maar zonder hen zou je geen dag doorkomen. Geef ze dus de aandacht die ze verdienen.</p>\n\n<p>In de volgende les gaan we kijken naar je darmen – misschien wel de meest onderschatte speler in detox. Want geloof me: als je darmen niet meewerken, kan geen enkel detoxplan écht slagen.</p>"
-    },
-    {
-      "id": "les-9",
-      "index": 9,
-      "title": "Les 9: De darmen: de poortwachters van je gezondheid",
-      "type": "Theorie",
-      "duration_min": 15,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 9</h2>\n<h3>De darmen: de poortwachters van je gezondheid</h3>\n\n<p>Jarenlang dacht ik dat mijn buikklachten gewoon \"normaal\" waren. Een beetje opgeblazen gevoel na het eten, af en toe buikpijn. Totdat ik ontdekte dat mijn darmen niet alleen maar mijn eten verteren – ze zijn ook dé poortwachters van mijn hele detoxsysteem.</p>\n\n<p>Je darmen bepalen namelijk wat er wél en níet in je bloed terechtkomt. Zie ze als een strenge beveiliging bij een club: gezonde voedingsstoffen mogen naar binnen, maar indringers en toxines horen buiten te blijven. Het probleem is alleen dat die beveiliging in onze tijd vaak verzwakt raakt.</p>\n\n<p>Dit kan gebeuren door:</p>\n\n<ul>\n<li><strong>Pesticiden en conserveermiddelen</strong> → ze verstoren het microbioom, de miljarden bacteriën die je darmen gezond houden.</li>\n<li><strong>Te veel suiker en bewerkt voedsel</strong> → die voeden de verkeerde bacteriën.</li>\n<li><strong>Stress</strong> → ook stresshormonen veranderen je darmflora en darmwand.</li>\n<li><strong>Medicijngebruik</strong> (zoals antibiotica of pijnstillers) → ze slopen niet alleen slechte, maar ook goede bacteriën.</li>\n</ul>\n\n<p>En als de darmwand poreus wordt – een fenomeen dat vaak \"leaky gut\" wordt genoemd – glippen toxines en onverteerde deeltjes tóch je bloedbaan in. Gevolg? Ontstekingen, vermoeidheid, huidproblemen en zelfs mentale klachten.</p>\n\n<p>Toen ik dit begreep, vielen er heel wat kwartjes. Want mijn opgeblazen gevoel bleek niet alleen maar vervelend; het was een signaal dat mijn detoxsysteem lekte.</p>\n\n<p>Gelukkig zijn er krachtige manieren om je darmen te ondersteunen:</p>\n\n<ul>\n<li><strong>Vezelrijke voeding</strong> → groenten, fruit, peulvruchten en volkoren producten voeden de goede bacteriën.</li>\n<li><strong>Gefermenteerd eten</strong> → denk aan zuurkool, kimchi, kefir of yoghurt met levende culturen.</li>\n<li><strong>Bottenbouillon of collageen</strong> → helpt de darmwand te herstellen.</li>\n<li><strong>Rust bij het eten</strong> → kauw goed en eet niet gehaast. Stress tijdens het eten remt je spijsvertering enorm.</li>\n</ul>\n\n<p>Wil je vandaag iets concreets doen? Voeg één gefermenteerd product toe aan je maaltijd van morgen. Het hoeft niet ingewikkeld te zijn – een lepeltje zuurkool naast je avondeten kan al verschil maken.</p>\n\n<p>Je darmen zijn geen passieve buis waar eten doorheen glijdt. Ze zijn een levend ecosysteem, dat bepaalt hoeveel toxines jouw lichaam überhaupt binnenkomen. Als je deze poortwachter sterk maakt, heb je al de helft van je detox gewonnen.</p>\n\n<p>En in de volgende les sluiten we dit hoofdstuk af met een vaak onderschatte kracht: slaap en herstel. Want detoxen gebeurt niet alleen overdag – je lichaam heeft de nacht nodig om écht schoon schip te maken.</p>"
-    },
-    {
-      "id": "les-10",
-      "index": 10,
-      "title": "Les 10: Slaap: jouw nachtelijke detox-lab",
-      "type": "Praktijk",
-      "duration_min": 16,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 10</h2>\n<h3>Slaap: jouw nachtelijke detox-lab</h3>\n\n<p>Er was een periode dat ik mezelf wijsmaakte dat ik prima op vijf uur slaap kon functioneren. Ik voelde me stoer: \"Ik ben productief, ik heb discipline.\" Maar de waarheid? Ik liep rond als een uitgeknepen citroen. Mijn huid werd valer, mijn energie zakte in en mijn hoofd voelde constant vol. Pas toen ik ontdekte wat er 's nachts in je lichaam gebeurt, begreep ik waarom slaap misschien wel de krachtigste detox-tool is die er bestaat.</p>\n\n<p>Tijdens diepe slaap gebeurt er iets magisch. Je hersenen openen letterlijk een speciaal \"schoonmaaksysteem\": het glymfatisch systeem. Dit spoelt afvalstoffen en toxines weg die zich overdag ophopen in je hersencellen. Denk aan een soort nachtelijke schoonmaakploeg die met emmers water alles uitspoelt.</p>\n\n<p>Maar dat is niet alles:</p>\n\n<ul>\n<li>Je lever draait 's nachts op volle toeren om gifstoffen af te breken.</li>\n<li>Je hormonen (zoals melatonine en groeihormoon) ondersteunen herstel en regeneratie.</li>\n<li>Je immuunsysteem voert een soort kwaliteitscontrole uit en verwijdert cellen die niet meer gezond zijn.</li>\n</ul>\n\n<p>Het is dus niet voor niets dat je na een slechte nacht vaak wazig, chagrijnig of futloos bent. Je detox-lab heeft simpelweg zijn werk niet kunnen doen.</p>\n\n<p>Toen ik mijn slaap ging prioriteren – vaste bedtijden, minder schermen in de avond, en een donkere slaapkamer – merkte ik dat mijn energie overdag veel stabieler werd. En die \"mist in mijn hoofd\" trok langzaam op.</p>\n\n<p>Wat jij vandaag kunt doen: kies één kleine verbetering voor je avond. Misschien een vast moment om je telefoon weg te leggen. Misschien een warme douche voor het slapengaan. Misschien een half uur eerder naar bed. Kleine stapjes, groot effect.</p>\n\n<p>Onthoud dit: detoxen gaat niet alleen over vermijden en afvoeren. Het gaat net zo goed over ruimte geven aan herstel. En slaap is daar de ultieme sleutel voor.</p>\n\n<p>Vanaf het volgende hoofdstuk duiken we voor het eerst écht diep een stof in: microplastics. Je gaat ontdekken hoe ze ongemerkt je lichaam binnenkomen en wat je kunt doen om ze kwijt te raken. Dat wordt een echte eye-opener.</p>"
-    },
-    {
-      "id": "les-11",
-      "index": 11,
-      "title": "Les 11: Microplastics: de onzichtbare vijand",
-      "type": "Theorie",
-      "duration_min": 18,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 11</h2>\n<h3>Microplastics: de onzichtbare vijand</h3>\n\n<p>Ik vergeet nooit meer het moment dat ik een onderzoek las waarin stond dat microplastics in het bloed van mensen waren gevonden. Het voelde bijna sciencefiction-achtig. Kleine stukjes plastic… ín ons bloed. En toch is het realiteit. Inmiddels hebben onderzoekers ze ook ontdekt in longen, darmen en zelfs in de placenta van baby's.</p>\n\n<p>Microplastics zijn piepkleine deeltjes plastic, vaak niet groter dan een zandkorrel. Ze ontstaan wanneer plastic producten afbreken: flesjes, kleding, verpakkingen, autobanden. Het bizarre is: ze zijn zo klein dat je ze niet ziet, maar je ademt ze in, je drinkt ze mee met water en je eet ze met je voedsel.</p>\n\n<p>De grootste bronnen zijn vaak verrassend dichtbij:</p>\n\n<ul>\n<li><strong>Kleding van polyester of fleece</strong> – elke wasbeurt laat duizenden vezels los.</li>\n<li><strong>Drinkwater</strong> – zelfs kraanwater bevat meetbare microplastics.</li>\n<li><strong>Voeding</strong> – vooral zeevruchten, omdat vissen en schelpdieren microplastics opnemen.</li>\n<li><strong>Lucht</strong> – stof in huis kan microplastics bevatten van meubels, tapijt of elektronica.</li>\n<li><strong>Plastic verpakkingen</strong> – bakjes, flessen, folie: alles waar voedsel in verpakt zit, laat kleine deeltjes los.</li>\n</ul>\n\n<p>Wat ik zelf schokkend vond: zelfs als je gezond eet, krijg je dit ongemerkt binnen. Ik dronk jarenlang elke dag uit een plastic flesje \"omdat dat makkelijk was\". Tot ik leerde dat die flesjes langzaam deeltjes afgeven aan het water dat ik dronk.</p>\n\n<p>Waarom is dit gevaarlijk? Omdat microplastics niet alleen in je lichaam blijven hangen, maar vaak ook chemicaliën met zich meedragen, zoals BPA of weekmakers. Ze zijn als kleine giftaxi's die je bloedbaan rondrijden.</p>\n\n<p>Nu wil ik je niet bang maken. Het is niet dat één slok water je vergiftigt. Het probleem is de constante blootstelling. Elke dag een beetje, jarenlang. En precies dáár gaan we verandering in brengen.</p>\n\n<p>Ik wil dat je vandaag één moment pakt om rond te kijken in je eigen omgeving: waar gebruik jij plastic zonder erbij stil te staan? Is het je drinkfles? Je boodschappentas? Je voedselverpakking? Schrijf één ding op waarvan je denkt: daar kan ik iets aan veranderen.</p>\n\n<p>Want de eerste stap naar minder microplastics is simpel: zien waar ze zitten.</p>\n\n<p>In de volgende les duiken we in hoe microplastics zich gedragen in je lichaam – en waarom je ze niet zomaar vanzelf uitplast of uitademt. Dat inzicht gaat je écht wakker schudden.</p>"
-    },
-    {
-      "id": "les-12",
-      "index": 12,
-      "title": "Les 12: Hoe microplastics zich ophopen in je lichaam",
-      "type": "Praktijk",
-      "duration_min": 14,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 12</h2>\n<h3>Hoe microplastics zich ophopen in je lichaam</h3>\n\n<p>Het meest bizarre aan microplastics is niet dat ze in ons eten of water zitten – maar dat ze in ons lichaam blijven hangen. Toen ik dat besefte, keek ik ineens met hele andere ogen naar mijn dagelijkse keuzes.</p>\n\n<p>Je lichaam is slim en probeert vreemde stoffen zo snel mogelijk kwijt te raken. Maar microplastics zijn letterlijk té klein en té hardnekkig. Ze glippen overal tussendoor:</p>\n\n<ul>\n<li><strong>In je longen</strong> → als je ze inademt, kunnen de kleinste deeltjes dieper dan je denkt, tot in je longblaasjes.</li>\n<li><strong>In je darmen</strong> → ze beschadigen het darmslijmvlies en kunnen daar ontstekingsreacties veroorzaken.</li>\n<li><strong>In je bloed</strong> → sommige microplastics zijn zo minuscuul dat ze de darmwand passeren en direct in je bloed terechtkomen.</li>\n<li><strong>In je organen</strong> → onderzoekers vonden ze al in lever- en nierweefsel.</li>\n<li><strong>In je hersenen</strong> → er zijn aanwijzingen dat nanoplastics zelfs de bloed-hersenbarrière kunnen doorkruisen.</li>\n</ul>\n\n<p>Het probleem is niet alleen dat ze aanwezig zijn. Het probleem is dat microplastics als een soort spons werken. Ze trekken chemicaliën aan, zoals pesticiden, zware metalen of weekmakers, en nemen die mee je lichaam in. Zie het als giftige lifters die overal met ze meereizen.</p>\n\n<p>De gevolgen? Ze verstoren je immuunsysteem, veroorzaken laaggradige ontstekingen en kunnen je hormonen beïnvloeden. En het vervelende: omdat het zo geleidelijk gebeurt, merk je vaak pas na maanden of jaren dat je energie lager is, je huid minder straalt of je weerstand minder wordt.</p>\n\n<p>Toen ik dit ontdekte, voelde ik me eerlijk gezegd even machteloos. \"Als ze overal zitten, wat heeft het dan voor zin?\" Maar precies dat is de verkeerde gedachte. Want hoe meer blootstelling je vermindert en hoe beter je je lichaam ondersteunt, hoe minder ruimte microplastics krijgen om zich op te stapelen.</p>\n\n<p>Denk eens na: welke van de plekken die ik net noemde (longen, darmen, bloed, organen) resoneert het meest met jou? Waar zou jij bang voor zijn dat dit impact heeft op jouw gezondheid? Schrijf het kort op. Het helpt je straks te zien waar je de meeste winst kunt boeken.</p>\n\n<p>In de volgende les ga ik je laten zien welke klachten en gezondheidsproblemen wetenschappers inmiddels koppelen aan microplastics. En geloof me: dat wordt een eye-opener, want veel van die klachten herken je misschien al bij jezelf.</p>"
-    },
-    {
-      "id": "les-13",
-      "index": 13,
-      "title": "Les 13: De impact van microplastics op je gezondheid",
-      "type": "Theorie",
-      "duration_min": 15,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 13</h2>\n<h3>De impact van microplastics op je gezondheid</h3>\n\n<p>Toen ik voor het eerst las dat microplastics in verband worden gebracht met vruchtbaarheidsproblemen, slikte ik even. Ik dacht altijd dat dit soort dingen \"ergens ver weg\" gebeurden, in fabrieken of bij mensen die dagelijks met plastic werken. Maar de realiteit? Wij allemaal hebben ze in ons lichaam, en ze laten wél degelijk sporen achter.</p>\n\n<p>De wetenschap staat nog in de kinderschoenen, maar steeds meer onderzoeken wijzen dezelfde kant op. Microplastics worden in verband gebracht met:</p>\n\n<ul>\n<li><strong>Ontstekingen</strong> → ze irriteren weefsels, waardoor je immuunsysteem constant op \"aan\" staat. Resultaat: vermoeidheid, vage pijntjes, huidproblemen.</li>\n<li><strong>Hormoonverstoring</strong> → doordat microplastics vaak weekmakers en BPA meenemen, kunnen ze je oestrogeen- en testosteronbalans verstoren.</li>\n<li><strong>Vruchtbaarheidsproblemen</strong> → er zijn aanwijzingen dat ze invloed hebben op spermakwaliteit en eicelgezondheid.</li>\n<li><strong>Hartaandoeningen</strong> → recent onderzoek laat zien dat microplastics in bloedvaten kunnen zitten en daar ontstekingen veroorzaken.</li>\n<li><strong>Neurologische effecten</strong> → nanoplastics die de hersenen bereiken, lijken invloed te hebben op stemming en concentratie.</li>\n</ul>\n\n<p>Toen ik dit las, moest ik denken aan de jaren dat ik altijd zo moe was. Ik kon er nooit precies mijn vinger op leggen. En hoewel je natuurlijk niet álles aan microplastics kunt wijten, voelde ik wel: dit speelt mee. Dit is een factor die we veel te vaak onderschatten.</p>\n\n<p>Wat belangrijk is om te begrijpen: het gaat niet om paniek of schuldgevoel. Je hoeft niet te denken: \"O, dit is allemaal mijn schuld.\" Jij hebt dit niet bedacht. Jij leeft in een wereld die vol zit met deze stoffen. En juist daarom is kennis macht. Want elke stap die je zet om blootstelling te verminderen, kan je gezondheid op de lange termijn beschermen.</p>\n\n<p>Neem een moment om dit op jezelf te betrekken: herken jij één of meer van deze klachten in je eigen leven? Vermoeidheid? Huidproblemen? Hormonen uit balans? Noteer wat je bij jezelf ziet. Niet om bang van te worden, maar om straks te kunnen zeggen: \"Hier heb ik verandering in aangebracht.\"</p>\n\n<p>In de volgende les ga ik je laten zien hoe je microplastics in je dagelijks leven drastisch kunt verminderen. En daar zitten tips bij die verrassend eenvoudig zijn – maar een enorm verschil kunnen maken.</p>"
-    },
-    {
-      "id": "les-14",
-      "index": 14,
-      "title": "Les 14: Hoe je opname van microplastics vermindert in je dagelijks leven",
-      "type": "Praktijk",
-      "duration_min": 16,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 14</h2>\n<h3>Hoe je opname van microplastics vermindert in je dagelijks leven</h3>\n\n<p>Toen ik stopte met het kopen van plastic waterflesjes en overstapte op een glazen fles, voelde het in eerste instantie als een klein gebaar. Maar weken later dacht ik: \"Wow, dit is waarschijnlijk één van de beste keuzes die ik heb gemaakt.\" Soms zit de kracht juist in zulke simpele aanpassingen.</p>\n\n<p>Microplastics vermijden klinkt onmogelijk – en volledig ontkomen doe je ook niet. Maar je kunt je blootstelling wel enorm verlagen met slimme keuzes. Hier zijn een paar van de meest impactvolle:</p>\n\n<h4>Drink uit glas of RVS, niet uit plastic</h4>\n<p>Plastic flesjes en bekers geven deeltjes af, vooral bij warmte. Glazen of RVS-flessen zijn veilig en gaan jaren mee.</p>\n\n<h4>Kies voor vers boven verpakt</h4>\n<p>Elke salade in een plastic bakje of maaltijd in plastic folie is een bron van microplastics. Door vaker vers te koken en losse producten te kopen, verminder je automatisch je inname.</p>\n\n<h4>Let op je kookgerei</h4>\n<p>Anti-aanbakpannen met een coating bevatten vaak PFAS én kunnen microdeeltjes loslaten. Kies voor gietijzer, roestvrij staal of keramisch kookgerei.</p>\n\n<h4>Wassen zonder microvezelregen</h4>\n<p>Synthetische kleding (polyester, fleece) laat duizenden vezels los bij elke wasbeurt. Was minder vaak, gebruik een waszak die microvezels opvangt, of kies vaker voor katoen, wol en linnen.</p>\n\n<h4>Filter je water</h4>\n<p>Veel kraanwater bevat microplastics. Een kwalitatief goed waterfilter kan dit sterk verminderen.</p>\n\n<h4>Vermijd wegwerpplastic waar je kunt</h4>\n<p>Tasjes, rietjes, plastic servies – het lijkt onschuldig, maar elk gebruik is extra microplastic in het milieu én uiteindelijk in je lichaam.</p>\n\n<p>Wat ik zelf heb ervaren: het gaat niet om alles tegelijk perfect doen. Het gaat om consistent kleine keuzes maken. Vervang één plastic product in je leven door een duurzaam alternatief en voel hoe dat je mindset verandert.</p>\n\n<p>Pak nu je notitieboekje en kies één gewoonte uit deze lijst waar jij vandaag nog mee kunt beginnen. Misschien is het je fles, misschien je pannen, misschien je wasroutine. Eén actie is genoeg.</p>\n\n<p>Want hoe meer microplastics je buiten de deur houdt, hoe minder je lichaam hoeft te vechten tegen de belasting van binnenuit.</p>\n\n<p>In de volgende les gaan we een stap verder: hoe je lichaam helpt om microplastics die al ín je systeem zitten, beter af te voeren. Dat is de missing link die vaak vergeten wordt.</p>"
-    },
-    {
-      "id": "les-15",
-      "index": 15,
-      "title": "Les 15: Microplastics afvoeren: voeding, beweging & supplementen",
-      "type": "Theorie",
-      "duration_min": 17,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 15</h2>\n<h3>Microplastics afvoeren: voeding, beweging & supplementen</h3>\n\n<p>Toen ik ontdekte dat ik al jarenlang dagelijks microplastics binnenkreeg, voelde dat eerst ontmoedigend. \"Ze zitten overal, hoe kom ik hier ooit vanaf?\" Maar dat veranderde toen ik me realiseerde: je lichaam hééft manieren om ermee om te gaan – je moet het alleen een handje helpen.</p>\n\n<p>Microplastics verdwijnen niet vanzelf, maar je kunt hun belasting wel verminderen en je lichaam sterker maken in het afvoeren. Dit zijn drie krachtige pijlers:</p>\n\n<h4>1. Voeding die bindt en neutraliseert</h4>\n\n<ul>\n<li><strong>Vezels</strong> uit groenten, fruit, peulvruchten en zaden zorgen dat afvalstoffen sneller via je darmen afgevoerd worden.</li>\n<li><strong>Chlorella en spirulina</strong> staan bekend om hun vermogen om gifstoffen en zelfs microplastics te binden.</li>\n<li><strong>Kruisbloemige groenten</strong> (broccoli, spruitjes, bloemkool) ondersteunen de lever, die de chemische stoffen die aan microplastics vastzitten neutraliseert.</li>\n<li><strong>Polyfenolen</strong> uit bessen, groene thee en kurkuma werken ontstekingsremmend en beschermen je cellen tegen schade.</li>\n</ul>\n\n<h4>2. Beweging & zweten</h4>\n\n<p>Beweging stimuleert de doorbloeding en helpt afvalstoffen sneller af te voeren. Zweten – of dat nu door sporten of een sauna is – is een directe route om toxines kwijt te raken via je huid. Ik merkte zelf dat een wekelijkse saunasessie mijn energie een enorme boost gaf, alsof mijn lijf letterlijk lichter werd.</p>\n\n<h4>3. Supplementen die ondersteunen</h4>\n\n<ul>\n<li><strong>Glutathion</strong> – het belangrijkste antioxidant van je lichaam, ondersteunt je lever bij detox.</li>\n<li><strong>NAC (N-acetylcysteïne)</strong> – een voorloper van glutathion, helpt je lichaam om dit zelf aan te maken.</li>\n<li><strong>Omega-3 vetzuren</strong> – verminderen ontstekingen die microplastics veroorzaken.</li>\n<li><strong>Vitamine C</strong> – ondersteunt je immuunsysteem en helpt bij het neutraliseren van vrije radicalen.</li>\n</ul>\n\n<p><strong>👉 Belangrijk:</strong> supplementen zijn nooit een excuus om door te gaan zoals je deed. Ze zijn een extra steuntje, bovenop voeding en levensstijl.</p>\n\n<h4>Jouw actie vandaag</h4>\n\n<p>Kies één van deze drie pijlers om mee te beginnen.</p>\n\n<ul>\n<li>Ga je meer vezels toevoegen aan je maaltijden?</li>\n<li>Plan je een sauna of zwetsessie na je training?</li>\n<li>Of begin je met een supplement dat je lever ondersteunt?</li>\n</ul>\n\n<p>Kleine stappen, grote impact. Elke keuze helpt je lichaam lichter te maken.</p>\n\n<p>Met dit sluitstuk heb je nu niet alleen begrepen wat microplastics zijn en hoe ze je belasten, maar ook hoe je ze actief kunt verminderen én afvoeren. En dat is precies de kracht van dit traject: kennis omzetten in actie.</p>\n\n<p>In het volgende hoofdstuk pakken we een andere, misschien nog wel hardnekkigere groep stoffen aan: PFAS – de zogenaamde \"forever chemicals\" die écht overal zitten. Dit wordt een grote eye-opener.</p>"
-    },
-    {
-      "id": "les-16-pfas-forever-chemicals",
-      "index": 16,
-      "title": "Les 16: PFAS: de 'forever chemicals'",
-      "type": "Theorie",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 16</h2>\n<h3>PFAS: de 'forever chemicals'</h3>\n\n<p>De eerste keer dat ik hoorde over PFAS, dacht ik eerlijk gezegd: \"Weer zo'n modewoord.\" Maar toen ik me erin verdiepte, schrok ik. Want PFAS zijn geen hype. Ze zijn letterlijk overal – en ze worden niet voor niets de 'forever chemicals' genoemd.</p>\n\n<p>PFAS (Per- en Polyfluoralkylstoffen) zijn een groep van duizenden chemische stoffen die sinds de jaren '50 worden gebruikt om materialen water-, vet- en vuilafstotend te maken. Klinkt handig, en dat is het ook: je regenjas blijft droog, je pan bakt niet aan, je pizza-doos zuigt geen vet door. Maar er is één groot probleem: ze breken bijna niet af. Niet in de natuur, niet in je lichaam.</p>\n\n<p>Dat betekent dat elke keer dat je met PFAS in aanraking komt, je lichaam er een beetje van opslaat. En omdat ze zo langzaam afbreken, stapelen ze zich jaar na jaar verder op. Wetenschappers hebben ze inmiddels gevonden in het bloed van bijna iedereen ter wereld – ja, ook bij jou en mij.</p>\n\n<h4>Waar kom je ze tegen? Waarschijnlijk vaker dan je denkt:</h4>\n\n<ul>\n<li>In <strong>anti-aanbakpannen</strong> met teflonlaag.</li>\n<li>In <strong>waterafstotende kleding</strong> en schoenen.</li>\n<li>In <strong>voedselverpakkingen</strong> zoals bakjes, zakjes en pizzadozen.</li>\n<li>In <strong>cosmetica</strong> – sommige foundations, mascara's en crèmes.</li>\n<li>Zelfs in <strong>drinkwater</strong> in gebieden rondom fabrieken die PFAS gebruiken.</li>\n</ul>\n\n<p>Het is bizar als je erover nadenkt: stoffen die ooit zijn gemaakt om ons leven makkelijker te maken, keren zich nu tegen ons eigen lichaam.</p>\n\n<p>Wat mij het meest raakte, was een onderzoek dat aantoonde dat PFAS zelfs in moedermelk worden teruggevonden. Dat betekent dat een baby al vanaf de eerste dag van zijn leven met deze stoffen te maken krijgt.</p>\n\n<p>En dat is precies waarom we er in dit hoofdstuk diep induiken. Want kennis geeft je de kracht om keuzes te maken – keuzes die je blootstelling beperken en je lichaam helpen sterker te blijven.</p>\n\n<p>In de volgende les ga ik je laten zien waarom PFAS zo gevaarlijk zijn voor je gezondheid – en vooral: waarom je ze níet zomaar kunt negeren.</p>"
-    },
-    {
-      "id": "les-17-pfas-health-risks",
-      "index": 17,
-      "title": "Les 17: Waarom PFAS zo gevaarlijk zijn voor je gezondheid",
-      "type": "Theorie",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 17</h2>\n<h3>Waarom PFAS zo gevaarlijk zijn voor je gezondheid</h3>\n\n<p>Wat PFAS zo verraderlijk maakt, is niet alleen dat ze overal zitten. Het echte probleem is dat je lichaam ze niet kan afbreken. Ze hechten zich aan eiwitten in je bloed en aan weefsels in je organen, en blijven daar… soms tientallen jaren.</p>\n\n<p>De impact is groot en veel breder dan je in eerste instantie denkt. Steeds meer studies laten zien dat PFAS invloed hebben op:</p>\n\n<h4>Hormonen</h4>\n<p>PFAS lijken zich te mengen in je hormoonsysteem. Ze verstoren de balans van oestrogeen, progesteron en testosteron. Gevolg? Cyclusproblemen, verminderd libido, lagere vruchtbaarheid en zelfs een verhoogd risico op PCOS en schildklierproblemen.</p>\n\n<h4>Vruchtbaarheid en ontwikkeling</h4>\n<p>Bij mannen is aangetoond dat PFAS de spermakwaliteit kunnen aantasten. Bij vrouwen is de kans op een verminderde eicelkwaliteit en een verstoorde hormoonhuishouding groter. En bij baby's? Wetenschappers hebben PFAS teruggevonden in de placenta en moedermelk.</p>\n\n<h4>Immuunsysteem</h4>\n<p>PFAS verzwakken de afweer. Er zijn aanwijzingen dat kinderen die blootgesteld zijn aan PFAS minder goed reageren op vaccinaties. Je lichaam wordt dus letterlijk minder weerbaar tegen ziektes.</p>\n\n<h4>Lever en cholesterol</h4>\n<p>PFAS hopen zich op in de lever, wat kan leiden tot verhoogde cholesterolwaarden en leverproblemen.</p>\n\n<h4>Kanker</h4>\n<p>Hoewel de wetenschap nog volop onderzoekt, zijn er sterke aanwijzingen dat langdurige blootstelling aan bepaalde PFAS het risico op nier- en testiskanker vergroot.</p>\n\n<p>Toen ik dit ontdekte, voelde ik het bijna persoonlijk. Alsof er een indringer in mijn huis zat die ik niet kon zien, maar die wel constant mijn spullen overhoop haalde. Want dat is precies wat PFAS doen: langzaam, stilletjes, structureel je systeem belasten.</p>\n\n<p>Maar hier komt het hoopvolle deel: je kúnt er iets tegen doen. Je kunt je blootstelling enorm terugbrengen en je lichaam ondersteunen bij het opruimen. Het vraagt geen radicale verandering, maar slimme keuzes in je dagelijks leven.</p>\n\n<p>Voordat we daar komen, wil ik je in de volgende les laten zien waar PFAS allemaal verstopt zitten. Ik kan je beloven: sommige ga je niet verwachten.</p>"
-    },
-    {
-      "id": "les-18-pfas-hidden-sources",
-      "index": 18,
-      "title": "Les 18: Waar PFAS écht verstopt zitten",
-      "type": "Praktijk",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 18</h2>\n<h3>Waar PFAS écht verstopt zitten</h3>\n\n<p>Toen ik mijn eigen huis eens kritisch naliep op PFAS, viel ik van de ene verbazing in de andere. Ik dacht: \"Oké, anti-aanbakpannen, die snap ik.\" Maar toen ik ontdekte dat mijn regenjas, mijn mascara en zelfs de pizzadoos van de supermarkt vol zaten met deze stoffen, voelde het alsof ik in een slechte grap beland was.</p>\n\n<p>PFAS zijn niet voor niets de 'forever chemicals'. Ze zitten in zoveel producten dat je ze ongemerkt tientallen keren per dag tegenkomt. Hier zijn een paar voorbeelden die vaak vergeten worden:</p>\n\n<h4>Keuken & eten</h4>\n<ul>\n<li>Anti-aanbakpannen met teflonlaag.</li>\n<li>Bakpapier en vetwerende pizzadozen.</li>\n<li>Fastfoodverpakkingen (denk aan frietzakjes en broodjespapier).</li>\n</ul>\n\n<h4>Kleding & textiel</h4>\n<ul>\n<li>Regenjassen en sportkleding met een waterafstotende laag.</li>\n<li>Tapijten en meubels die \"vlekbestendig\" zijn gemaakt.</li>\n<li>Schoenen met een beschermende coating.</li>\n</ul>\n\n<h4>Cosmetica & verzorging</h4>\n<ul>\n<li>Mascara's, foundations en lippenstiften (voor glans en waterproof-effect).</li>\n<li>Crèmes die glad en langdurig smeerbaar zijn.</li>\n</ul>\n\n<h4>Huishouden</h4>\n<ul>\n<li>Brandblusschuim (vooral bij mensen die in die sector werken).</li>\n<li>Sommige schoonmaakmiddelen.</li>\n</ul>\n\n<h4>Drinkwater</h4>\n<p>Vooral in gebieden rond fabrieken die PFAS gebruiken, maar ook elders zijn lage concentraties gemeten.</p>\n\n<p>Wat ik zelf bizar vond: ik gebruikte jarenlang een mascara waar PFAS in zaten. Nooit bij stilgestaan dat iets wat ik dagelijks op mijn ogen smeerde, een stof bevatte die mijn hormonen zou kunnen verstoren.</p>\n\n<p>Dit is de kracht van bewustwording: zodra je weet waar het zit, kun je keuzes maken. Je hoeft niet alles in één keer te vervangen. Maar elke stap die je zet – een nieuwe pan, een andere fles, een natuurlijkere mascara – verlaagt de druk op je lichaam.</p>\n\n<p>Kijk eens rond in je eigen leven. Waar denk jij dat PFAS zich bij jou het meest verschuilen? Is het in de keuken? In je kleding? Of misschien in je cosmetica? Schrijf het op. Het is vaak verrassend hoe snel je een paar concrete punten kunt ontdekken.</p>\n\n<p>In de volgende les gaan we precies bespreken hoe je jouw blootstelling aan PFAS drastisch kunt verminderen. En daar zitten oplossingen bij die eenvoudig en haalbaar zijn.</p>"
-    },
-    {
-      "id": "les-19-pfas-exposure-reduction",
-      "index": 19,
-      "title": "Les 19: Hoe je jouw blootstelling aan PFAS drastisch vermindert",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 19</h2>\n<h3>Hoe je jouw blootstelling aan PFAS drastisch vermindert</h3>\n\n<p>Toen ik eenmaal doorhad waar PFAS allemaal verstopt zitten, voelde ik me eerlijk gezegd even machteloos. Het zat in zoveel producten dat ik dacht: \"Hoe kan ik dit ooit vermijden?\" Maar stap voor stap ontdekte ik dat je wél veel invloed hebt. Het gaat niet om 100% perfect leven – het gaat om de grootste bronnen slim aanpakken.</p>\n\n<p>Hier zijn een paar krachtige strategieën die je meteen kunt toepassen:</p>\n\n<h4>1. In de keuken</h4>\n<ul>\n<li>Vervang anti-aanbakpannen met teflon door gietijzer, roestvrij staal of keramisch.</li>\n<li>Vermijd bakpapier en fastfoodverpakkingen – kies voor herbruikbare bakmatjes of gewoon ouderwets bakblik.</li>\n<li>Kies vaker voor verse, losse producten in plaats van verpakt fastfood.</li>\n</ul>\n\n<h4>2. Kleding & textiel</h4>\n<ul>\n<li>Check labels: termen als \"waterafstotend\" of \"vlekbestendig\" zijn vaak een rode vlag.</li>\n<li>Ga voor kleding van natuurlijke materialen zoals katoen, wol en linnen.</li>\n<li>Was nieuwe kleding altijd voor gebruik – dit spoelt een deel van de chemicaliën weg.</li>\n</ul>\n\n<h4>3. Cosmetica & verzorging</h4>\n<ul>\n<li>Vermijd producten met ingrediënten zoals PTFE of fluoro (vaak verstopt in de INCI-lijst).</li>\n<li>Kies voor merken die transparant zijn over PFAS-vrije formules.</li>\n<li>Less is more: hoe minder laagjes je dagelijks smeert, hoe lager je belasting.</li>\n</ul>\n\n<h4>4. Drinkwater</h4>\n<ul>\n<li>Overweeg een waterfilter dat PFAS eruit haalt (zoals actieve koolfilters).</li>\n<li>Check de kwaliteit van jouw regio via openbare waterdata.</li>\n</ul>\n\n<h4>5. Algemeen huishouden</h4>\n<ul>\n<li>Laat wegwerpschoonmaakmiddelen met \"supercoating\" links liggen.</li>\n<li>Ventileer je huis regelmatig – ook textiel en meubels kunnen PFAS uitstoten.</li>\n</ul>\n\n<p>Toen ik mijn eerste stap zette – mijn oude pannen vervangen – voelde dat bijna symbolisch. Alsof ik letterlijk een bron van gif het huis uit gooide. En dat gaf me motivatie om verder te kijken.</p>\n\n<p><strong>👉 Wat jij nu kunt doen:</strong> kies vandaag één product in je huis dat je de komende weken wilt vervangen door een PFAS-vrije variant. Begin klein. Misschien een pan, misschien een mascara, misschien een waterfles. Elk stapje verlaagt je dagelijkse belasting.</p>\n\n<p>In de volgende les gaan we nog een stap verder: hoe je je lichaam actief kunt ondersteunen om PFAS die al ín je systeem zitten, sneller kwijt te raken.</p>"
-    },
-    {
-      "id": "les-20-pfas-detox-support",
-      "index": 20,
-      "title": "Les 20: Hoe je je lichaam helpt PFAS sneller kwijt te raken",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 20</h2>\n<h3>Hoe je je lichaam helpt PFAS sneller kwijt te raken</h3>\n\n<p>Het frustrerende aan PFAS is dat ze bijna niet afbreken. Ze worden niet voor niets \"forever chemicals\" genoemd. Maar dat betekent niet dat je machteloos bent. Je lichaam hééft manieren om ermee om te gaan – en jij kunt dat proces ondersteunen.</p>\n\n<p>Toen ik hiermee begon, was mijn mindset: \"Ik moet ze er zo snel mogelijk uitgooien.\" Maar dat is niet realistisch. Het draait om stap voor stap je belasting verlagen, zodat je lichaam langzaam ruimte krijgt om op te ruimen.</p>\n\n<h4>1. Voeding die helpt</h4>\n<ul>\n<li><strong>Vezelrijke voeding</strong> (groenten, fruit, peulvruchten) → bindt afvalstoffen in de darmen zodat ze niet terug je lichaam in circuleren.</li>\n<li><strong>Kruisbloemige groenten</strong> (broccoli, spruitjes, boerenkool) → ondersteunen leverenzymen die PFAS kunnen neutraliseren.</li>\n<li><strong>Antioxidanten</strong> (bessen, groene thee, kurkuma) → beschermen je cellen tegen ontstekingen die PFAS veroorzaken.</li>\n<li><strong>Chlorella & spirulina</strong> → er zijn aanwijzingen dat deze algen PFAS en andere chemicaliën kunnen binden en afvoeren.</li>\n</ul>\n\n<h4>2. Beweging & zweten</h4>\n<p>Beweging stimuleert je circulatie en je lymfestelsel – waardoor je afvalstoffen sneller afvoert. Zweten (door sporten, sauna of zelfs een warm bad) is een directe manier om toxines kwijt te raken via je huid. Ik merkte zelf dat mijn wekelijkse sauna een soort \"resetknop\" werd.</p>\n\n<h4>3. Supplementen die ondersteunen</h4>\n<ul>\n<li><strong>Glutathion</strong> → je lichaamseigen \"master antioxidant\", cruciaal in ontgifting.</li>\n<li><strong>NAC (N-acetylcysteïne)</strong> → helpt je lichaam glutathion zelf aan te maken.</li>\n<li><strong>Omega-3 vetzuren</strong> → remmen ontstekingsreacties die PFAS veroorzaken.</li>\n<li><strong>Vitamine C & E</strong> → versterken je afweer en neutraliseren vrije radicalen.</li>\n</ul>\n\n<h4>4. Leefstijl</h4>\n<ul>\n<li><strong>Slaap</strong> → je lever werkt 's nachts harder dan overdag. Te weinig slaap betekent minder detoxcapaciteit.</li>\n<li><strong>Stressmanagement</strong> → chronische stress zet je lichaam in overlevingsstand en vermindert je ontgiftingskracht. Ademhalingsoefeningen, wandelen en stilte zijn simpele maar effectieve tools.</li>\n</ul>\n\n<p><strong>👉 Wat jij vandaag kunt doen:</strong> kies één manier om je lichaam meer te ondersteunen. Misschien een extra portie broccoli, misschien een avondwandeling, misschien een supplement dat je toevoegt. Het gaat niet om alles tegelijk – maar om consistent kleine stapjes.</p>\n\n<p>Met dit hoofdstuk heb je de \"forever chemicals\" ontmaskerd én strategieën in handen om hun impact te verminderen. En geloof me: elke keuze telt.</p>\n\n<p>In het volgende hoofdstuk duiken we in een nieuwe vijand: pesticiden en gif in voeding. Dit is misschien wel de meest directe en dagelijkse bron van toxines die we binnenkrijgen – en er zijn simpele manieren om jezelf hiertegen te beschermen.</p>"
-    },
-    {
-      "id": "les-21-pesticides-hidden-cocktail",
-      "index": 21,
-      "title": "Les 21: Pesticiden: de verborgen gif-cocktail in je voeding",
-      "type": "Theorie",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 21</h2>\n<h3>Pesticiden: de verborgen gif-cocktail in je voeding</h3>\n\n<p>Ik weet nog dat ik een keer een schaal druiven kocht. Ze zagen er prachtig uit: glanzend, knapperig, zoet. Maar toen ik ze thuis afspoelde, bleef er een vettig laagje achter op mijn vingers. En ik dacht: \"Wat zit hier eigenlijk op?\" Het antwoord? Een cocktail van pesticiden.</p>\n\n<p>Pesticiden zijn bestrijdingsmiddelen die worden gebruikt om gewassen te beschermen tegen insecten, schimmels en onkruid. Klinkt logisch – niemand wil dat zijn oogst wordt opgegeten door beestjes – maar er zit een keerzijde. Diezelfde stoffen die insecten doden, komen óók op ons bord terecht.</p>\n\n<p>En vaak gaat het niet om één stof, maar om meerdere tegelijk. Onderzoek laat zien dat groenten en fruit soms wel resten van vijf tot tien verschillende pesticiden bevatten. En het lichaam herkent dat niet als iets kleins, maar als een voortdurende stroom van gifstoffen.</p>\n\n<h4>Wat maakt dit zo gevaarlijk?</h4>\n\n<ul>\n<li><strong>Hormonale verstoring:</strong> veel pesticiden bootsen hormonen na of blokkeren receptoren.</li>\n<li><strong>Zenuwstelsel:</strong> sommige pesticiden zijn neurotoxisch en kunnen je concentratie en stemming beïnvloeden.</li>\n<li><strong>Kankerverwekkend:</strong> er zijn stoffen waarvan duidelijk bewezen is dat ze het risico op kanker verhogen.</li>\n<li><strong>Darmflora:</strong> pesticiden doden niet alleen ongedierte, maar verstoren ook de goede bacteriën in je darmen.</li>\n</ul>\n\n<p>Toen ik dit ontdekte, begreep ik ineens waarom ik vroeger altijd dacht dat ik \"gezond\" at, maar me toch niet gezond voelde. Ik at groente en fruit – maar tegelijk nam ik een onzichtbare dosis gif mee naar binnen.</p>\n\n<p>Het klinkt heftig, maar hier zit ook juist de kracht: dit is een bron van toxines waar je heel concreet invloed op hebt. De keuzes die jij maakt bij de supermarkt of op de markt, bepalen direct hoeveel gifstoffen je binnenkrijgt.</p>\n\n<p>Sta eens stil bij de laatste dagen. Hoe vaak heb jij groente of fruit gegeten dat uit de supermarkt kwam? En hoe vaak was het biologisch of onbewerkt? Schrijf dit op. Niet om jezelf schuldig te voelen, maar om inzicht te krijgen.</p>\n\n<p>In de volgende les ga ik je laten zien wat \"biologisch\" nou écht betekent – en wat niet. Want geloof me: er bestaan heel wat misverstanden over dat label.</p>"
-    },
-    {
-      "id": "les-22-biological-meaning",
-      "index": 22,
-      "title": "Les 22: Wat 'biologisch' wél en níet betekent",
-      "type": "Theorie",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 22</h2>\n<h3>Wat 'biologisch' wél en níet betekent</h3>\n\n<p>Toen ik de overstap maakte naar meer biologische producten, dacht ik in eerste instantie: \"Yes, probleem opgelost. Biologisch = helemaal schoon.\" Maar al snel ontdekte ik dat dit beeld te simpel was. Het label \"biologisch\" is waardevol, maar ook vaak verkeerd begrepen.</p>\n\n<h4>Wat biologisch wel betekent:</h4>\n<ul>\n<li>Er worden geen <strong>synthetische pesticiden</strong> gebruikt, maar natuurlijke bestrijdingsmiddelen.</li>\n<li>Er wordt geen <strong>kunstmest</strong> gebruikt, maar meststoffen uit de natuur.</li>\n<li><strong>Genetisch gemodificeerde organismen (GMO's)</strong> zijn niet toegestaan.</li>\n<li>Dieren krijgen meer ruimte, betere voeding en minder antibiotica.</li>\n</ul>\n\n<h4>Wat biologisch niet betekent:</h4>\n<ul>\n<li>Dat het product <strong>100% gifvrij</strong> is. Ook natuurlijke bestrijdingsmiddelen laten soms residuen achter.</li>\n<li>Dat het altijd <strong>voedzamer</strong> is. Biologisch kan wél hogere voedingsstoffen bevatten (bijv. meer antioxidanten), maar dat verschilt per product.</li>\n<li>Dat het <strong>milieuneutraal</strong> is. Biologische landbouw heeft vaak meer land nodig, wat ook een impact heeft.</li>\n</ul>\n\n<p>Dus ja, biologisch is meestal een betere keuze voor je gezondheid, maar het is niet de magische oplossing die vaak gesuggereerd wordt.</p>\n\n<p>Wat mij hielp, was dit inzicht: biologisch eten gaat niet over perfectie, maar over minder belasting voor je lichaam. Een appel die met natuurlijke middelen is behandeld, is voor je lijf een stuk vriendelijker dan een appel met een mix van synthetische pesticiden.</p>\n\n<p>En er is nog iets: biologisch eten heeft ook te maken met accumulatie. Hoe vaker jij kiest voor biologisch, hoe minder gifstoffen zich in de loop der tijd in je lichaam opstapelen. Het gaat dus om de lange termijn.</p>\n\n<p>Een simpele oefening: kies drie producten die je vaak eet – bijvoorbeeld appels, tomaten en aardbeien. Ga eens na of je die biologisch kunt kopen. Begin daar. Je hoeft niet meteen alles biologisch te doen. Focus op wat je vaak gebruikt – daar maak je de grootste winst.</p>\n\n<p>In de volgende les gaan we kijken naar de echte kracht van voeding: welke detox-boosters er bestaan die pesticiden in je lichaam neutraliseren en je lever helpen om ze af te voeren.</p>"
-    },
-    {
-      "id": "les-23-pesticide-detox-boosters",
-      "index": 23,
-      "title": "Les 23: Detox-boosters die pesticiden neutraliseren",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 23</h2>\n<h3>Detox-boosters die pesticiden neutraliseren</h3>\n\n<p>Toen ik ontdekte dat ik pesticiden niet alleen kon vermijden, maar ook kon neutraliseren, voelde dat als een enorme opluchting. Want je kunt nog zo je best doen om biologisch te eten – helemaal vermijden lukt niet. Maar er zijn voedingsstoffen en planten die je lichaam écht helpen bij het afbreken en opruimen van pesticiden.</p>\n\n<p>Dit zijn een paar van de krachtigste boosters:</p>\n\n<h4>1. Kruisbloemige groenten</h4>\n<p>Broccoli, spruitjes, bloemkool en boerenkool bevatten stoffen (zoals sulforafaan) die je leverenzymen activeren. Hierdoor worden pesticiden sneller omgezet in onschadelijke stoffen.</p>\n\n<h4>2. Knoflook & ui</h4>\n<p>Deze bevatten zwavelverbindingen die je lever ondersteunen bij detox. Ze helpen gifstoffen te binden zodat ze je lichaam kunnen verlaten.</p>\n\n<h4>3. Koriander & peterselie</h4>\n<p>Koriander staat erom bekend dat het zware metalen en pesticiden kan binden. Peterselie werkt vochtafdrijvend en ondersteunt je nieren bij het afvoeren.</p>\n\n<h4>4. Antioxidanten</h4>\n<p>Bessen, groene thee en kurkuma zijn rijk aan antioxidanten. Ze beschermen je cellen tegen de oxidatieve stress die pesticiden veroorzaken.</p>\n\n<h4>5. Vezels</h4>\n<p>Vezels zijn misschien wel de meest onderschatte detox-tool. Ze zorgen dat afvalstoffen (waaronder pesticiden) gebonden worden in je darmen en met je ontlasting meegaan, in plaats van dat ze terug in je bloed komen.</p>\n\n<p>Ik merkte zelf verschil toen ik dagelijks een smoothie maakte met spinazie, blauwe bessen en een schepje lijnzaad. Het was simpel, maar gaf me een gevoel van lichtheid en meer energie. Kleine gewoontes kunnen een groot effect hebben.</p>\n\n<p><strong>👉 Oefening voor jou:</strong> voeg vandaag één van deze boosters toe aan je maaltijd. Misschien een extra portie broccoli, een handje bessen of een scheutje kurkuma in je thee. Noteer hoe je je voelt als je dit een paar dagen volhoudt.</p>\n\n<p>In de volgende les gaan we praktisch worden: hoe je met simpele trucs bij het koken en wassen de hoeveelheid pesticiden op je eten drastisch kunt verminderen.</p>"
-    },
-    {
-      "id": "les-24-smart-cooking-washing-pesticides",
-      "index": 24,
-      "title": "Les 24: Slim koken en wassen om pesticiden te verminderen",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 24</h2>\n<h3>Slim koken en wassen om pesticiden te verminderen</h3>\n\n<p>Toen ik eenmaal wist hoeveel pesticiden er op groente en fruit kunnen zitten, dacht ik: \"Moet ik dan alles biologisch kopen?\" Maar dat is niet altijd haalbaar of betaalbaar. Gelukkig zijn er simpele trucs waarmee je de belasting van pesticiden flink kunt verlagen – gewoon in je eigen keuken.</p>\n\n<h4>1. Grondig wassen</h4>\n<p>Afspoelen onder de kraan haalt een deel van de pesticiden weg, maar niet alles. Beter is:</p>\n<ul>\n<li>Maak een water-azijnoplossing (1 deel azijn, 3 delen water) en laat je groente/fruit 10 minuten weken.</li>\n<li>Of gebruik baksoda in water (een eetlepel per liter). Dit breekt een groot deel van pesticiden af.</li>\n</ul>\n<p>Studies tonen aan dat hiermee veel meer resten verdwijnen dan met gewoon afspoelen.</p>\n\n<h4>2. Schillen</h4>\n<p>Bij sommige producten (appels, komkommers, aardappelen) zit een groot deel van de pesticiden op of net onder de schil. Schillen kan een groot verschil maken – al verlies je wel wat vezels en voedingsstoffen.</p>\n\n<h4>3. Koken en blancheren</h4>\n<p>Warmte kan bepaalde pesticiden deels afbreken. Koken, stomen of blancheren vermindert de hoeveelheid resten. Dat betekent niet dat je alles moet koken, maar het helpt zeker.</p>\n\n<h4>4. Slim kiezen</h4>\n<p>Sommige producten bevatten standaard veel pesticiden (zoals aardbeien, druiven en paprika's), terwijl anderen vaak relatief schoon zijn (zoals avocado's, bananen en uien). Focus je was- en kookinspanningen vooral op de \"besmette\" producten.</p>\n\n<h4>5. Variatie</h4>\n<p>Door steeds verschillende groente en fruit te eten, verminder je het risico dat je te veel van één bepaalde pesticidenstof binnenkrijgt. Variatie is dus ook een detox-strategie.</p>\n\n<p>Ik merkte zelf dat mijn energie stabieler werd toen ik dit structureel ging toepassen. Niet omdat ik ineens gifvrij at, maar omdat ik de belasting van mijn lichaam zichtbaar omlaag bracht.</p>\n\n<p><strong>👉 Jouw opdracht:</strong> kies vandaag één product dat je vaak eet (bijvoorbeeld appels of druiven) en pas één van deze methodes toe. Maak het tastbaar voor jezelf.</p>\n\n<p>In de volgende les van dit hoofdstuk ronden we pesticiden af met een krachtige stap: hoe jij de regie terugpakt over je voeding – en zorgt dat je structureel minder gif binnenkrijgt zonder dat het ingewikkeld wordt.</p>"
-    },
-    {
-      "id": "les-25-taking-control-food",
-      "index": 25,
-      "title": "Les 25: De regie terugpakken over je voeding",
-      "type": "Praktijk",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 25</h2>\n<h3>De regie terugpakken over je voeding</h3>\n\n<p>Ik herinner me nog dat ik vroeger in de supermarkt altijd een beetje machteloos langs de schappen liep. Alles leek verpakt, behandeld of bespoten. Tot ik me realiseerde: \"Ik hoef niet alles perfect te doen, maar ík bepaal wél wat ik koop.\" Vanaf dat moment voelde voeding niet langer als iets wat mij overkwam, maar als iets waar ik controle over had.</p>\n\n<p>De kracht zit in drie simpele stappen:</p>\n\n<h4>1. Ken je \"Dirty Dozen\" en \"Clean Fifteen\"</h4>\n<p>In de VS wordt elk jaar een lijst gepubliceerd van groente en fruit met de hoogste (Dirty Dozen) en laagste (Clean Fifteen) pesticidenbelasting. In Nederland liggen de waarden soms iets anders, maar het principe werkt ook hier.</p>\n<p><strong>👉 Focus op biologisch bij producten die vaak hoog scoren (aardbeien, druiven, paprika's). Bij producten die al laag scoren (avocado's, uien, bananen) kun je gerust voor regulier kiezen.</strong></p>\n\n<h4>2. Eet lokaal en seizoensgebonden</h4>\n<p>Producten die van ver komen, krijgen vaak extra behandelingen om de reis te overleven. Lokale seizoensgroente en -fruit bevatten vaak minder residuen én zijn voedzamer. Denk aan Hollandse appels in de herfst of asperges in de lente.</p>\n\n<h4>3. Plan vooruit</h4>\n<p>Als je op het laatste moment boodschappen doet, grijp je sneller naar gemak – en dus vaak naar bespoten of verpakt eten. Door wekelijks je maaltijden te plannen, kies je bewuster en voorkom je dat pesticiden ongemerkt je bord domineren.</p>\n\n<p>Wat ik zelf merkte: hoe meer ik me verdiepte in de herkomst van mijn eten, hoe meer plezier ik kreeg in koken en eten. Het voelde niet als restrictie, maar als rijkdom: ik wíst waar mijn voeding vandaan kwam en ik voelde me er beter bij.</p>\n\n<p><strong>👉 Jouw actie:</strong> schrijf drie producten op die je het komende seizoen standaard biologisch of lokaal wilt kopen. Maak er een gewoonte van en bouw van daaruit verder.</p>\n\n<p>Met deze stap sluit je het pesticiden-hoofdstuk af. Je weet nu niet alleen hoe gevaarlijk ze kunnen zijn, maar ook hoe jij je blootstelling drastisch kunt verlagen én je lichaam kunt ondersteunen in het afvoeren.</p>\n\n<p>In het volgende hoofdstuk duiken we in een ander groot thema: BPA en ftalaten – de stille hormoonverstoorders die letterlijk overal in ons dagelijks leven verstopt zitten.</p>"
-    },
-    {
-      "id": "les-26-bpa-phthalates-hormone-disruptors",
-      "index": 26,
-      "title": "Les 26: BPA en ftalaten: de stille hormoonverstoorders",
-      "type": "Theorie",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 26</h2>\n<h3>BPA en ftalaten: de stille hormoonverstoorders</h3>\n\n<p>Ik weet nog dat ik een keer bij de kassa stond en mijn bonnetje aanpakte. Pas later ontdekte ik dat die kassabon vol zat met BPA – een stof die mijn hormonen kon beïnvloeden. Vanaf dat moment keek ik ineens heel anders naar de simpelste dingen in mijn dagelijks leven.</p>\n\n<p>BPA (Bisfenol A) en ftalaten (weekmakers) zijn misschien wel de meest onderschatte toxines in ons leven. Waarom? Omdat ze niet direct een \"gifgevoel\" geven. Je voelt niet na één aanraking iets geks. Maar ondertussen doen ze wél iets op de achtergrond: ze verstoren je hormoonsysteem.</p>\n\n<p>BPA wordt vooral gebruikt in plastics en coatings (denk aan plastic flessen, voedselblikken, kassabonnen). Ftalaten maken plastic flexibel en zitten in alles van speelgoed tot douchegordijnen – en zelfs in cosmetica.</p>\n\n<h4>Wat ze doen in je lichaam:</h4>\n\n<ul>\n<li><strong>Bootsen hormonen na</strong> (vooral oestrogeen). Hierdoor raken je natuurlijke hormoonprocessen uit balans.</li>\n<li><strong>Verlagen testosteron</strong> → vooral bij mannen een groot probleem: minder spieropbouw, lager libido, vermoeidheid.</li>\n<li><strong>Beïnvloeden vruchtbaarheid</strong> → studies koppelen BPA en ftalaten aan verminderde spermakwaliteit en verstoring van de eicelontwikkeling.</li>\n<li><strong>Vergroten risico op hormonale aandoeningen</strong> → denk aan PCOS, schildklierproblemen, overgewicht.</li>\n</ul>\n\n<p>Het enge is dat BPA en ftalaten niet in je lichaam blijven zoals PFAS – ze worden relatief snel weer uitgescheiden. Maar… omdat je er elke dag opnieuw mee in aanraking komt, zit er bijna continu een hoeveelheid in je bloed. Het is alsof je lichaam nooit een pauze krijgt.</p>\n\n<p>Toen ik dit besefte, snapte ik waarom ik mijn energie soms niet kon verklaren. Het was niet één grote bron van stress, maar een continue \"ruis\" die mijn systeem in de war bracht.</p>\n\n<p>En dat is precies wat we in dit hoofdstuk gaan aanpakken: zien waar BPA en ftalaten verstopt zitten, begrijpen hoe ze ons beïnvloeden, en leren hoe we ze zoveel mogelijk uit ons leven bannen.</p>\n\n<p>In de volgende les laat ik je zien waar deze stoffen allemaal verborgen zijn in ons dagelijks leven – en geloof me, sommige ga je totaal niet verwachten.</p>"
-    },
-    {
-      "id": "les-27-bpa-phthalates-hidden-sources",
-      "index": 27,
-      "title": "Les 27: Waar BPA en ftalaten zich verstoppen",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 27</h2>\n<h3>Waar BPA en ftalaten zich verstoppen</h3>\n\n<p>Toen ik eenmaal wist dat BPA en ftalaten hormoonverstoorders zijn, dacht ik: \"Oke, dan vermijd ik gewoon plastic flesjes en klaar.\" Maar al snel ontdekte ik dat het veel dieper gaat. Deze stoffen zitten letterlijk overal om ons heen – vaak op plekken waar je ze het minst verwacht.</p>\n\n<p>Een paar van de meest voorkomende bronnen:</p>\n\n<h4>1. Voeding & drinken</h4>\n<ul>\n<li>Plastic flessen en bakjes → vooral als ze warm worden, laten ze BPA of ftalaten los.</li>\n<li>Conservenblikken → de binnenkant is vaak bekleed met BPA-houdende hars.</li>\n<li>Plastic folie en magnetronbakjes → bij verhitting komt er extra veel vrij.</li>\n</ul>\n\n<h4>2. Kassabonnen</h4>\n<p>Die gladde, glanzende bonnetjes bevatten vaak hoge hoeveelheden BPA. En omdat de stof via je huid wordt opgenomen, is een paar seconden vasthouden al genoeg om in je bloed te belanden.</p>\n\n<h4>3. Cosmetica & verzorging</h4>\n<ul>\n<li>Parfum, nagellak, haarspray en sommige crèmes bevatten ftalaten als oplosmiddel of fixeerder.</li>\n<li>Vaak herkenbaar in de ingrediëntenlijst aan termen als DEP of phthalate – maar soms ook volledig weggelaten.</li>\n</ul>\n\n<h4>4. Speelgoed & huishouden</h4>\n<ul>\n<li>Goedkoop plastic speelgoed bevat vaak ftalaten om het flexibel te maken.</li>\n<li>Ook douchegordijnen, vloerbedekking en opblaasbare producten (zoals zwembaden of luchtbedden).</li>\n</ul>\n\n<h4>5. Medische en schoonmaakproducten</h4>\n<p>Zelfs infuuszakken en sommige schoonmaakmiddelen bevatten ftalaten. Vooral voor mensen die veel in ziekenhuizen werken, kan dit een extra bron zijn.</p>\n\n<p>Wat ik zelf een eye-opener vond: mijn oude deodorant. Ik dacht dat ik een \"frisse keuze\" maakte, maar in de ingrediëntenlijst stond een ftalaatverbinding. Dat betekende dus dat ik elke dag bewust mijn oksels insmeerde met een hormoonverstoorder.</p>\n\n<p><strong>👉 Jouw opdracht voor vandaag:</strong> loop één kamer in je huis door (keuken, badkamer of slaapkamer) en kijk waar jij vermoedelijk BPA of ftalaten gebruikt. Het gaat niet om alles meteen vervangen, maar om bewustwording.</p>\n\n<p>In de volgende les duiken we dieper: hoe deze stoffen precies inwerken op je hormonen – en waarom dat zo'n groot effect heeft op energie, vruchtbaarheid en gezondheid.</p>"
-    },
-    {
-      "id": "les-28-bpa-phthalates-hormone-impact",
-      "index": 28,
-      "title": "Les 28: Hoe BPA en ftalaten je hormonen beïnvloeden",
-      "type": "Theorie",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 28</h2>\n<h3>Hoe BPA en ftalaten je hormonen beïnvloeden</h3>\n\n<p>Toen ik ontdekte dat BPA en ftalaten je hormonen kunnen imiteren, voelde dat bijna sciencefiction. Alsof er nep-hormonen in je lijf rondlopen die zich voordoen als de echte. Maar dat is precies wat er gebeurt – en daarom zijn ze zo schadelijk.</p>\n\n<h4>Hoe werkt het?</h4>\n\n<p>Hormonen zijn de boodschappers van je lichaam. Ze vertellen je cellen wanneer ze energie moeten maken, wanneer je moet slapen, wanneer je vruchtbaar bent, wanneer je moet herstellen. BPA en ftalaten lijken qua structuur op sommige van deze hormonen – vooral oestrogeen. Daardoor kunnen ze zich binden aan dezelfde receptoren.</p>\n\n<p>Het gevolg?</p>\n<ul>\n<li>Je cellen krijgen verkeerde signalen.</li>\n<li>Je natuurlijke hormoonbalans raakt verstoord.</li>\n<li>Processen die normaal strak geregeld zijn, lopen in de soep.</li>\n</ul>\n\n<h4>Wat merk je daarvan?</h4>\n\n<ul>\n<li><strong>Bij vrouwen:</strong> cyclusproblemen, PMS, vruchtbaarheidsproblemen, grotere kans op PCOS of endometriose.</li>\n<li><strong>Bij mannen:</strong> dalend testosteron, verminderde spermakwaliteit, lager libido en vermoeidheid.</li>\n<li><strong>Bij kinderen:</strong> verstoring van de puberteit, leer- en gedragsproblemen worden in verband gebracht met blootstelling.</li>\n<li><strong>Bij iedereen:</strong> meer kans op gewichtstoename, schildklierproblemen en hormonale disbalans.</li>\n</ul>\n\n<p>Toen ik dit begreep, vielen bij mij veel puzzelstukjes. Mijn energie die soms ineens instortte. Het gevoel dat ik niet helemaal \"in balans\" was. Ik had het altijd geweten, maar nooit kunnen benoemen. Tot ik besefte dat die kleine dagelijkse blootstelling aan BPA en ftalaten misschien wel een grote rol speelde.</p>\n\n<h4>Het sluipende effect</h4>\n\n<p>Het gevaar zit 'm niet in een keer een flesje water drinken uit plastic. Het gevaar zit in dagelijkse herhaling. Een beetje via je shampoo, een beetje via je eten, een beetje via die kassabon. Samen vormen ze een continue belasting die je hormonen dag in dag uit onder druk zet.</p>\n\n<p><strong>👉 Denk eens na:</strong> herken jij signalen die passen bij hormonale verstoring? Schrijf ze op, hoe klein ook. Het kan vermoeidheid zijn, een schommelende cyclus, of moeite om spieren op te bouwen. Dit helpt je straks de link te leggen met je detoxreis.</p>\n\n<p>In de volgende les gaan we kijken naar hoe je BPA en ftalaten actief uit je leven kunt bannen – en dat is makkelijker dan je denkt.</p>"
-    },
-    {
-      "id": "les-29-bpa-phthalates-elimination",
-      "index": 29,
-      "title": "Les 29: Hoe je BPA en ftalaten actief uit je leven bant",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 29</h2>\n<h3>Hoe je BPA en ftalaten actief uit je leven bant</h3>\n\n<p>Toen ik dit zelf serieus begon te nemen, merkte ik dat het niet ging om één grote radicale verandering. Het waren juist de kleine, bewuste stappen die het verschil maakten. Binnen een paar weken voelde ik me lichter en helderder, simpelweg omdat ik elke dag minder hormoonverstoorders binnenkreeg.</p>\n\n<p>Hier zijn praktische stappen die je meteen kunt toepassen:</p>\n\n<h4>1. In de keuken</h4>\n<ul>\n<li>Gebruik glas, RVS of keramiek in plaats van plastic bakjes en flesjes.</li>\n<li>Verwarm nooit eten in plastic (ook niet \"magnetronbestendig\"). Warmte zorgt dat BPA en ftalaten vrijkomen.</li>\n<li>Kies voor verse of glazen verpakkingen i.p.v. blik en plastic waar mogelijk.</li>\n</ul>\n\n<h4>2. In de supermarkt</h4>\n<ul>\n<li>Pak kassabonnen alleen aan als het moet, en bewaar ze niet in je zak of tas.</li>\n<li>Vermijd ingeblikte producten die aan de binnenkant met BPA bekleed zijn (soepblikken, frisdrankblikjes).</li>\n</ul>\n\n<h4>3. In de badkamer</h4>\n<ul>\n<li>Check etiketten van cosmetica en parfum. Vermijd producten met \"phthalate\" of \"DEP\".</li>\n<li>Kies voor natuurlijke deodorant, shampoos en crèmes zonder verborgen plastics.</li>\n<li>Minder is vaak beter: hoe minder laagjes je smeert, hoe lager je blootstelling.</li>\n</ul>\n\n<h4>4. In huis</h4>\n<ul>\n<li>Let op goedkoop plastic speelgoed en PVC-producten (zoals douchegordijnen of opblaasartikelen).</li>\n<li>Ventileer je huis dagelijks: ftalaten komen ook vrij uit meubels en vloerbedekking.</li>\n</ul>\n\n<h4>5. Slim kiezen</h4>\n<p>Zoek naar merken die BPA-vrij of phthalate-free aangeven. Dit is tegenwoordig steeds vaker te vinden.</p>\n\n<p>Toen ik overstapte op glazen bewaarpotjes en een RVS drinkfles, voelde het eerst als een kleine lifestyle upgrade. Maar achteraf gezien was het een enorme gezondheidsupgrade. Het zijn dit soort beslissingen die je lichaam structureel minder belasten.</p>\n\n<p><strong>👉 Jouw opdracht:</strong> kies één plek in je leven (keuken, badkamer of huishouden) en vervang daar deze week één product door een BPA- of ftalaatvrij alternatief. Zo begin je met zichtbare, haalbare stappen.</p>\n\n<p>In de volgende les ga ik je laten zien hoe je je lichaam actief ondersteunt om BPA en ftalaten sneller kwijt te raken – met voeding, beweging en supplementen. Dat is de missing link die veel mensen vergeten.</p>"
-    },
-    {
-      "id": "les-30-bpa-phthalates-detox-hacks",
-      "index": 30,
-      "title": "Les 30: Detox-hacks om BPA en ftalaten sneller kwijt te raken",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 30</h2>\n<h3>Detox-hacks om BPA en ftalaten sneller kwijt te raken</h3>\n\n<p>Wat mij geruststelde toen ik dit pad begon: BPA en ftalaten blijven niet decennia in je lichaam zoals PFAS. Je lichaam kan ze wel degelijk uitscheiden – maar alleen als jij het de juiste steun geeft. Het probleem is dat de meeste mensen elke dag zóveel nieuwe binnenkrijgen, dat hun systeem nooit echt leeg raakt.</p>\n\n<p>Als jij je blootstelling vermindert (zoals je in de vorige les hebt gezien) én je lichaam actief helpt afvoeren, kun je binnen weken verschil merken.</p>\n\n<h4>1. Voeding als bondgenoot</h4>\n<ul>\n<li><strong>Groene bladgroenten</strong> (spinazie, boerenkool, andijvie) leveren chlorofyl, wat helpt bij het binden en afvoeren van gifstoffen.</li>\n<li><strong>Vezelrijke voeding</strong> (havermout, peulvruchten, chiazaad) voorkomt dat BPA en ftalaten via je darmen terug in je bloed circuleren.</li>\n<li><strong>Kruiden</strong> zoals koriander en peterselie staan bekend om hun ontgiftende werking.</li>\n<li><strong>Gefermenteerde voeding</strong> (zuurkool, kefir, kimchi) versterkt je darmflora, die cruciaal is bij detox.</li>\n</ul>\n\n<h4>2. Beweging & zweten</h4>\n<p>Regelmatig bewegen stimuleert je lymfestelsel en helpt afvalstoffen sneller af te voeren. En zweten – of dat nu via sporten of een sauna is – is een van de krachtigste manieren waarop je lichaam BPA en ftalaten kwijt kan. Ik merkte zelf dat een paar keer per week intensief sporten mijn energie veel stabieler maakte.</p>\n\n<h4>3. Supplementen die ondersteunen</h4>\n<ul>\n<li><strong>Glutathion en NAC</strong> → versterken je lever bij het neutraliseren van hormoonverstoorders.</li>\n<li><strong>Chlorella</strong> → werkt als een soort spons die gifstoffen kan binden.</li>\n<li><strong>Omega-3</strong> → helpt ontstekingen te remmen die veroorzaakt worden door deze stoffen.</li>\n</ul>\n\n<h4>4. Leefstijl</h4>\n<ul>\n<li><strong>Slaap</strong> is je natuurlijke resetknop. Te weinig slaap = te weinig detox.</li>\n<li><strong>Hydratatie</strong> → voldoende water drinken ondersteunt je nieren om deze stoffen via urine uit te scheiden.</li>\n</ul>\n\n<p><strong>👉 Wat jij nu kunt doen:</strong> kies vandaag één van deze hacks en voeg 'm toe aan je routine. Begin bijvoorbeeld met een smoothie met spinazie en chiazaad, of plan een saunabezoek. Het hoeft niet ingewikkeld te zijn – consistentie maakt het verschil.</p>\n\n<p>Met dit sluitstuk heb je nu grip op BPA en ftalaten: je weet wat ze doen, waar ze zitten, hoe je ze vermijdt én hoe je je lichaam helpt ze af te voeren.</p>\n\n<p>In het volgende hoofdstuk stappen we in een nieuwe wereld: parabenen en toxines in cosmetica. Dit raakt ons dagelijks, vaak zonder dat we het doorhebben – en zeker voor vrouwen kan dit een gamechanger zijn.</p>"
-    },
-    {
-      "id": "les-31-parabens-hidden-toxins-cosmetics",
-      "index": 31,
-      "title": "Les 31: Parabenen: de verborgen toxines in cosmetica",
-      "type": "Theorie",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>�� Les 31</h2>\n<h3>Parabenen: de verborgen toxines in cosmetica</h3>\n\n<p>Ik dacht jarenlang dat mijn verzorgingsproducten juist goed voor me waren. Mijn crème voelde luxe, mijn shampoo rook heerlijk en mijn deodorant gaf me zelfvertrouwen. Totdat ik leerde wat er écht in zat. En geloof me: dat was een klap in mijn gezicht.</p>\n\n<p>Parabenen zijn conserveermiddelen die worden toegevoegd aan cosmetica en verzorgingsproducten om ze langer houdbaar te maken. Klinkt handig, maar er is een probleem: parabenen zijn hormoonverstoorders. Ze bootsen oestrogeen na in je lichaam en stapelen zich op in je weefsels.</p>\n\n<p>Wetenschappers hebben parabenen zelfs teruggevonden in borstweefsel en tumoren. Dat betekent niet dat parabenen direct kanker veroorzaken, maar wel dat ze zich ophopen in plekken waar ze niets te zoeken hebben.</p>\n\n<h4>Waar kom je ze tegen? Waarschijnlijk vaker dan je denkt:</h4>\n\n<ul>\n<li><strong>Shampoo en conditioner</strong></li>\n<li><strong>Bodylotion en crèmes</strong></li>\n<li><strong>Deodorant</strong></li>\n<li><strong>Make-up</strong> (foundation, mascara, lippenstift)</li>\n<li><strong>Scheerschuim en douchegel</strong></li>\n</ul>\n\n<p>Toen ik dit ontdekte, voelde het bijna alsof ik mezelf elke dag onbewust insmeerde met troep. Want dat is precies wat er gebeurt: via je huid komen parabenen rechtstreeks in je bloedbaan terecht.</p>\n\n<p>En dit raakt niet alleen vrouwen. Ook mannen die dagelijks deo, gel of aftershave gebruiken, krijgen parabenen binnen. Het effect op hormonen geldt voor iedereen.</p>\n\n<p><strong>👉 Jouw opdracht:</strong> pak vandaag eens 2 of 3 producten uit je badkamer en check het etiket. Zoek naar namen als methylparaben, propylparaben, butylparaben. Vaak staan ze helemaal onderaan de ingrediëntenlijst. Het kan confronterend zijn, maar dit is de eerste stap naar bewustwording.</p>\n\n<p>In de volgende les ga ik je laten zien hoe parabenen precies invloed hebben op je hormonen en gezondheid – en waarom dat subtiele klachten kan geven die je misschien nooit met je deo of crème in verband had gebracht.</p>"
-    },
-    {
-      "id": "les-32-parabens-body-impact",
-      "index": 32,
-      "title": "Les 32: Hoe parabenen je lichaam beïnvloeden",
-      "type": "Theorie",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 32</h2>\n<h3>Hoe parabenen je lichaam beïnvloeden</h3>\n\n<p>Toen ik ontdekte dat parabenen niet alleen in mijn crème zaten, maar ook nog eens in mijn bloed terug te vinden waren, dacht ik: \"Hoe kan zoiets legaal zijn?\" Het antwoord: omdat de effecten subtiel zijn en vaak pas na jaren zichtbaar worden. Maar dat maakt ze niet minder gevaarlijk.</p>\n\n<h4>Parabenen en hormonen</h4>\n\n<p>Parabenen zijn zogeheten xeno-oestrogenen: stoffen die in je lichaam oestrogeen nadoen. Je cellen herkennen het verschil niet goed en reageren alsof er meer oestrogeen aanwezig is dan werkelijk het geval is.</p>\n\n<ul>\n<li><strong>Bij vrouwen</strong> kan dit leiden tot cyclusproblemen, PMS, verminderde vruchtbaarheid of een hoger risico op aandoeningen als endometriose.</li>\n<li><strong>Bij mannen</strong> zorgt het voor dalend testosteron, verminderde spermakwaliteit en minder spieropbouw.</li>\n</ul>\n\n<h4>Ophoping in weefsel</h4>\n\n<p>Onderzoeken hebben parabenen aangetoond in borstweefsel, vooral bij vrouwen die jarenlang cosmetica met parabenen gebruikten. Het betekent niet dat parabenen dé oorzaak zijn van borsttumoren, maar wel dat ze zich ophopen op plekken waar hormonen al een grote rol spelen.</p>\n\n<h4>Ontstekingen en huidproblemen</h4>\n\n<p>Omdat parabenen de huid binnendringen, kunnen ze ook lokaal irritatie en laaggradige ontstekingen veroorzaken. Denk aan eczeem, jeuk of huiduitslag die vaak wordt weggewuifd als \"gevoelige huid\".</p>\n\n<h4>Het sluipende gevaar</h4>\n\n<p>Het verraderlijke is dat parabenen snel uit je bloed verdwijnen, maar omdat je ze elke dag opnieuw gebruikt, is er een constante stroom. Daardoor staat je lichaam continu onder subtiele druk.</p>\n\n<p>Toen ik zelf overstapte op parabenenvrije verzorging, merkte ik binnen weken verschil. Mijn huid voelde rustiger en ik had het idee dat mijn energie stabieler werd. Misschien deels placebo, maar dat maakte me eerlijk gezegd niet uit – mijn lichaam voelde lichter.</p>\n\n<p><strong>👉 Vraag aan jou:</strong> gebruik jij dagelijks producten met parabenen? En heb je ooit klachten gehad die je misschien niet direct linkte aan cosmetica – zoals huidirritatie, vermoeidheid of hormoonschommelingen? Noteer dit eens. Het kan straks waardevolle inzichten opleveren.</p>\n\n<p>In de volgende les ga ik je laten zien waar parabenen vaak verstopt zitten zonder dat je het doorhebt – en hoe je die kunt herkennen op labels. Dit wordt een echte eye-opener.</p>"
-    },
-    {
-      "id": "les-33-parabens-hidden-labels",
-      "index": 33,
-      "title": "Les 33: Waar parabenen zich verstoppen & hoe je labels leest",
-      "type": "Praktijk",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 33</h2>\n<h3>Waar parabenen zich verstoppen & hoe je labels leest</h3>\n\n<p>Ik dacht ooit dat parabenen alleen in goedkope producten zaten. Maar toen ik mijn eigen \"luxe\" gezichtscrème pakte en het etiket las, stonden ze er gewoon in. Dat was echt een wake-up call. Want parabenen zijn slim verstopt: vaak diep in de ingrediëntenlijst, met namen die bijna niemand herkent.</p>\n\n<h4>Typische plekken waar parabenen zich verstoppen</h4>\n\n<ul>\n<li><strong>Haarproducten</strong> → shampoo, conditioner, haarspray.</li>\n<li><strong>Crèmes & bodylotions</strong> → vooral producten die lang houdbaar moeten blijven.</li>\n<li><strong>Make-up</strong> → foundation, mascara, lippenstift.</li>\n<li><strong>Deodorant</strong> → veelgebruikte bron van parabenen direct op gevoelige huid.</li>\n<li><strong>Scheerproducten</strong> → scheerschuim, aftershave.</li>\n</ul>\n\n<h4>Hoe herken je parabenen op het etiket?</h4>\n\n<p>Zoek naar namen die eindigen op -paraben. De meest voorkomende zijn:</p>\n\n<ul>\n<li>Methylparaben</li>\n<li>Propylparaben</li>\n<li>Butylparaben</li>\n<li>Ethylparaben</li>\n</ul>\n\n<p>Fabrikanten gebruiken vaak meerdere soorten tegelijk. Soms staan ze helemaal onderaan de ingrediëntenlijst, waardoor je ze makkelijk over het hoofd ziet.</p>\n\n<h4>Misleiding in marketing</h4>\n\n<p>Wat ik zelf frustrerend vond: sommige merken zetten groot \"Natuurlijk!\" of \"Dermatologisch getest!\" op de verpakking, terwijl er gewoon parabenen in zaten. Laat je dus niet foppen door de voorkant – de waarheid staat altijd op de achterkant.</p>\n\n<p><strong>👉 Oefening voor jou:</strong> pak vandaag drie verzorgingsproducten uit je badkamer en lees het etiket. Schrijf op of je parabenen vindt. Dit is vaak een shock, maar het geeft je direct inzicht in hoeveel je dagelijks binnenkrijgt.</p>\n\n<p>In de volgende les laat ik je zien hoe je praktische, schone alternatieven kunt kiezen – zonder dat je badkamer ineens leeg of saai wordt.</p>"
-    },
-    {
-      "id": "les-34-clean-alternatives-parabens",
-      "index": 34,
-      "title": "Les 34: Schone alternatieven: zo kies je cosmetica zonder parabenen",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 34</h2>\n<h3>Schone alternatieven: zo kies je cosmetica zonder parabenen</h3>\n\n<p>Toen ik besloot om parabenen te vermijden, dacht ik eerst dat ik alles in mijn badkamer de prullenbak in moest gooien. Maar dat bleek gelukkig niet nodig. Er zijn tegenwoordig zóveel goede alternatieven – en vaak werken ze net zo goed (of beter) dan de oude producten.</p>\n\n<h4>1. Kies voor transparante merken</h4>\n\n<p>Zoek merken die duidelijk aangeven \"parabenenvrij\" of \"phthalate-free\". Vaak hebben ze dit zelfs op de voorkant staan. Let op: sommige merken doen aan greenwashing en gebruiken vage termen als \"natuurlijk\" of \"pure care\". Dat zegt niets. Kijk altijd naar de ingrediëntenlijst.</p>\n\n<h4>2. Basisproducten zonder troep</h4>\n\n<ul>\n<li><strong>Deodorant</strong> → natuurlijke deo's op basis van baking soda, magnesium of zink werken verrassend goed.</li>\n<li><strong>Shampoo & conditioner</strong> → er zijn steeds meer merken die sulfaat- én parabenenvrij zijn. Vaak schuimen ze iets minder, maar reinigen ze net zo goed.</li>\n<li><strong>Bodylotion & crèmes</strong> → kies voor producten met korte ingrediëntenlijsten. Hoe minder, hoe beter.</li>\n<li><strong>Make-up</strong> → steeds meer clean beauty merken bieden foundation, mascara en lippenstift zonder parabenen.</li>\n</ul>\n\n<h4>3. DIY hacks</h4>\n\n<p>Soms is het simpeler dan je denkt. Kokosolie kan bijvoorbeeld als make-upremover dienen, en aloë vera-gel als lichte moisturizer. Niet alles hoeft uit een potje te komen.</p>\n\n<h4>4. Less is more</h4>\n\n<p>Wat ik zelf merkte: hoe minder producten ik dagelijks gebruikte, hoe beter mijn huid en energie werden. Soms denk je dat je tien producten nodig hebt, terwijl drie goede basics genoeg zijn.</p>\n\n<p><strong>👉 Jouw actie:</strong> kies één verzorgingsproduct dat je dagelijks gebruikt (bijvoorbeeld je deo of je dagcrème) en vervang dit door een schone, parabenenvrije variant. Zo bouw je stap voor stap een badkamer op waar je lichaam blij van wordt.</p>\n\n<p>In de volgende les sluiten we dit hoofdstuk af met een stap die vaak vergeten wordt: hoe je zelf natuurlijke, eenvoudige verzorgingsproducten kunt maken – zodat je 100% weet wat er in zit.</p>"
-    },
-    {
-      "id": "les-35-diy-natural-care-hacks",
-      "index": 35,
-      "title": "Les 35: DIY hacks voor natuurlijke verzorging",
-      "type": "Praktijk",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 35</h2>\n<h3>DIY hacks voor natuurlijke verzorging</h3>\n\n<p>Toen ik eenmaal doorhad hoeveel rommel er in mijn dagelijkse producten zat, wilde ik meer controle. Het idee dat ik zelf iets kon maken – met ingrediënten die ik kende en kon uitspreken – gaf me vrijheid. En eerlijk? Het bleek veel simpeler (en leuker) dan ik dacht.</p>\n\n<p>Hier zijn een paar DIY hacks die je direct kunt proberen:</p>\n\n<h4>1. Natuurlijke deodorant</h4>\n<p>Basis: kokosolie (antibacterieel) + baking soda (neutraliseert geur) + maïszetmeel of arrowroot (absorbeert vocht).</p>\n<p>Optioneel: een paar druppels etherische olie (bijv. lavendel of tea tree).</p>\n<p><strong>👉 Meng tot een zachte pasta en bewaar in een klein potje.</strong></p>\n\n<h4>2. Bodylotion / moisturizer</h4>\n<p>Basis: sheaboter of cacaoboter smelten, mengen met kokosolie en laten opstijven.</p>\n<p>Optioneel: vitamine E-olie toevoegen voor huidherstel.</p>\n<p><strong>👉 Resultaat: een rijke, voedende crème zonder toevoegingen.</strong></p>\n\n<h4>3. Make-up remover</h4>\n<p>Gewoon pure kokosolie of jojoba-olie werkt beter dan veel commerciële removers. Zelfs waterproof mascara verdwijnt in seconden.</p>\n\n<h4>4. Lippenbalsem</h4>\n<p>Basis: bijenwas + kokosolie + sheaboter smelten en laten stollen.</p>\n<p><strong>👉 Eventueel wat cacao toevoegen voor een lichte kleur en geur.</strong></p>\n\n<h4>5. Haarmasker</h4>\n<p>Avocado + olijfolie + honing mengen → voedt je haar en hoofdhuid intensief.</p>\n\n<p>Het mooie? Je weet precies wat erin zit, je hebt geen chemische rommel nodig én vaak is het goedkoper dan dure merken.</p>\n\n<p>Ik dacht vroeger dat dit allemaal veel werk zou zijn. Maar de meeste recepten kosten nog geen 5 minuten om te maken. En het geeft een fijn gevoel van onafhankelijkheid: jij bepaalt wat je op je huid smeert.</p>\n\n<p><strong>👉 Oefening voor jou:</strong> kies één DIY hack die je aanspreekt en probeer 'm deze week uit. Schrijf op hoe je huid of haar reageert – en hoe jij je erbij voelt dat je dit zelf in de hand hebt.</p>\n\n<p>Met deze stap sluit je het parabenen-hoofdstuk af. Je weet nu hoe ze werken, waar ze zitten, hoe je ze vermijdt én hoe je zelfs je eigen alternatieven kunt maken.</p>\n\n<p>In het volgende hoofdstuk gaan we breder kijken: detox door levensstijl. Want voeding en cosmetica zijn belangrijk, maar hoe je beweegt, ademt, slaapt en ontspant, bepaalt net zo goed hoeveel gifstoffen je lichaam kan verwerken.</p>"
-    },
-    {
-      "id": "les-36-lifestyle-hidden-detox-key",
-      "index": 36,
-      "title": "Les 36: Levensstijl: de verborgen sleutel tot detox",
-      "type": "Theorie",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 36</h2>\n<h3>Levensstijl: de verborgen sleutel tot detox</h3>\n\n<p>Toen ik begon met detoxen, dacht ik dat het alleen ging om wat ik at of welke producten ik gebruikte. Maar pas later ontdekte ik dat mijn dagelijkse gewoontes misschien wel net zo belangrijk waren. Want hoe je beweegt, slaapt, ademt en ontspant, bepaalt of je lichaam voldoende ruimte krijgt om gifstoffen echt los te laten.</p>\n\n<p>Denk er eens over na: je kunt nog zo gezond eten, maar als je chronisch gestrest bent of te weinig slaapt, stapelt de troep zich alsnog op. Je lever en je immuunsysteem hebben namelijk rust, zuurstof en beweging nodig om optimaal te werken.</p>\n\n<h4>De vier pijlers van een detoxende levensstijl</h4>\n\n<ul>\n<li><strong>Beweging</strong> – stimuleert je lymfestelsel, waardoor afvalstoffen in beweging komen en sneller afgevoerd worden.</li>\n<li><strong>Zweten</strong> – je huid is je grootste detoxorgaan. Via zweten kun je letterlijk gifstoffen kwijt.</li>\n<li><strong>Ademhaling</strong> – diepe, bewuste ademhaling helpt niet alleen stress los te laten, maar ook CO₂ en vluchtige stoffen af te voeren.</li>\n<li><strong>Ontspanning & herstel</strong> – stress blokkeert je detox. Ontspanning opent de poort voor herstel.</li>\n</ul>\n\n<p>Wat ik zelf ervoer: zodra ik mijn levensstijl ging aanpassen, merkte ik sneller resultaat van alles wat ik al deed met voeding en producten. Het voelde alsof ik mijn lichaam eindelijk de kans gaf om door te pakken.</p>\n\n<p><strong>👉 Oefening:</strong> neem vandaag een paar minuten om stil te staan bij jouw huidige levensstijl. Beweeg je dagelijks voldoende? Slaap je echt diep? Adem je bewust of oppervlakkig? Noteer kort wat je eerste gedachten zijn.</p>\n\n<p>In de volgende lessen gaan we deze pijlers één voor één uitpluizen. We beginnen met iets wat je direct kunt toepassen: beweging en de kracht van je lymfesysteem.</p>"
-    },
-    {
-      "id": "les-37-movement-lymphatic-system",
-      "index": 37,
-      "title": "Les 37: Beweging & je lymfesysteem: de verborgen detoxmotor",
-      "type": "Praktijk",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 37</h2>\n<h3>Beweging & je lymfesysteem: de verborgen detoxmotor</h3>\n\n<p>Ik wist lange tijd niet eens wat mijn lymfesysteem deed. Ik dacht dat detox vooral een taak was van de lever en de nieren. Tot ik ontdekte dat je lymfesysteem eigenlijk je interne riool is – en dat beweging de pomp is die dit systeem aan de gang houdt.</p>\n\n<h4>Wat is je lymfesysteem?</h4>\n\n<p>Het is een netwerk van vaten en knopen dat afvalstoffen, gifstoffen en overtollig vocht afvoert. Je immuuncellen \"reizen\" erdoorheen en pakken onderweg virussen, bacteriën en toxines op. Het is letterlijk je schoonmaakploeg.</p>\n\n<p>Maar hier zit de catch: je lymfesysteem heeft geen pomp zoals je hart. Het beweegt alleen als jíj beweegt. Zit je veel stil? Dan staat je lymfe bijna stil – en blijven afvalstoffen langer in je lichaam hangen.</p>\n\n<h4>Hoe beweging je detoxkracht verdubbelt</h4>\n\n<ul>\n<li><strong>Wandelen</strong> → zelfs een kwartier per dag zet je lymfestroom al in beweging.</li>\n<li><strong>Sporten</strong> → krachttraining of cardio stimuleert circulatie en versnelt afvalafvoer.</li>\n<li><strong>Springen of trampoline</strong> → misschien gek, maar rebounding (trampoline springen) is één van de krachtigste manieren om je lymfesysteem te activeren.</li>\n<li><strong>Yoga & stretchen</strong> → bewegingen en twists helpen letterlijk afvalstoffen uit je weefsels los te maken.</li>\n</ul>\n\n<p>Toen ik zelf structureel meer ging wandelen (gewoon 20 minuten na het eten), merkte ik dat mijn spijsvertering beter liep en dat ik me minder \"zwaar\" voelde. Het lijkt klein, maar je lichaam voelt het verschil.</p>\n\n<h4>Jouw actie vandaag</h4>\n\n<p>Sta op en beweeg. Al is het 5 minuten springen, een korte wandeling of een rondje stretchen. Merk hoe je lichaam direct anders aanvoelt. Je geeft je interne riool letterlijk een zetje.</p>\n\n<p>In de volgende les duiken we in een ander krachtig mechanisme: zweten als detoxkanaal. Want wat je lichaam niet via je lever of nieren kwijt kan, verlaat je vaak via je huid.</p>"
-    },
-    {
-      "id": "les-38-sweating-detox-channel",
-      "index": 38,
-      "title": "Les 38: Zweten: je huid als detoxkanaal",
-      "type": "Praktijk",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 38</h2>\n<h3>Zweten: je huid als detoxkanaal</h3>\n\n<p>De eerste keer dat ik in de sauna zat en na tien minuten letterlijk het zweet van mijn armen zag druppelen, dacht ik: \"Dit is toch gewoon water?\" Maar toen ik ontdekte dat zweet óók gifstoffen bevat – van zware metalen tot ftalaten – keek ik er opeens heel anders naar. Je huid is namelijk je grootste orgaan, en zweten is één van de manieren waarop je lichaam afvalstoffen kwijt kan.</p>\n\n<h4>Waarom zweten zo krachtig is</h4>\n\n<ul>\n<li><strong>Afvoer van toxines</strong> → studies tonen aan dat je via zweet sporen van zware metalen (zoals lood en cadmium) én hormoonverstoorders kunt uitscheiden.</li>\n<li><strong>Ondersteuning van je nieren</strong> → doordat je via de huid afvalstoffen loost, hoeven je nieren minder hard te werken.</li>\n<li><strong>Circulatie boost</strong> → zweten gaat altijd samen met verhoogde doorbloeding, wat helpt om afvalstoffen los te maken en af te voeren.</li>\n</ul>\n\n<h4>Manieren om meer te zweten (zonder dat het ongemakkelijk wordt)</h4>\n\n<ul>\n<li><strong>Intensief sporten</strong> – een stevige HIIT, bokstraining of hardloopronde.</li>\n<li><strong>Sauna of infrarood sauna</strong> – krachtige detox-tool, ook goed voor ontspanning.</li>\n<li><strong>Warm bad</strong> – ook een heet bad kan je lichaam stimuleren tot transpireren.</li>\n<li><strong>Buiten bewegen</strong> – wandelen of fietsen in de zon doet vaak meer dan je denkt.</li>\n</ul>\n\n<p>Wat ik zelf merkte: na een periode waarin ik regelmatig naar de sauna ging, voelde ik mijn huid frisser en mijn hoofd helderder. Alsof er letterlijk een laag van me af was gegleden.</p>\n\n<h4>Kleine oefening voor jou</h4>\n\n<p>Plan deze week één moment om bewust te zweten. Dat kan een sportles zijn, een sauna of zelfs een heet bad. Merk op hoe je je daarna voelt – vaak is het niet alleen lichamelijk lichter, maar ook mentaal.</p>\n\n<p>In de volgende les gaan we kijken naar een factor die vaak onderschat wordt: ademhaling. Want zelfs de manier waarop je ademt kan bepalen hoeveel afvalstoffen je kwijt raakt én hoeveel stress je lichaam vasthoudt.</p>"
-    },
-    {
-      "id": "les-39-breathing-detox-stress-release",
-      "index": 39,
-      "title": "Les 39: Ademhaling: detox én stress-release",
-      "type": "Praktijk",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 39</h2>\n<h3>Ademhaling: detox én stress-release</h3>\n\n<p>Ik dacht vroeger dat ademhalen gewoon iets was dat vanzelf ging. Je doet het tienduizenden keren per dag, waarom zou je daar bij stilstaan? Tot ik ontdekte dat mijn manier van ademen invloed had op zowel mijn energie als mijn vermogen om gifstoffen kwijt te raken.</p>\n\n<h4>Ademhaling als detox</h4>\n\n<p>Elke uitademing is letterlijk een afvoer van afvalstoffen: je scheidt koolstofdioxide (CO₂) uit, maar ook vluchtige stoffen die je longen willen lozen. Hoe dieper en rustiger je ademhaling, hoe efficiënter dit proces werkt.</p>\n\n<p>Bij oppervlakkig, hoog ademen blijft een groot deel van je longen onbenut. Je gebruikt alleen de bovenste regionen, terwijl de onderste longblaasjes – waar de meeste detox plaatsvindt – nauwelijks aan bod komen.</p>\n\n<h4>Ademhaling en stress</h4>\n\n<p>Wat ik zelf pas laat doorhad: stress verandert je ademhaling. Je gaat sneller, oppervlakkiger en hoger ademen. Hierdoor denkt je lichaam dat je in \"overlevingsstand\" zit. En guess what? In die stand gaat je detox-systeem op slot. Je lijf kiest voor overleven, niet voor opruimen.</p>\n\n<h4>Simpele technieken die werken</h4>\n\n<ul>\n<li><strong>Buikademhaling</strong> – leg een hand op je buik, adem diep in zodat je hand omhoogkomt, langzaam uit zodat hij weer zakt. Doe dit 5 minuten en je parasympatisch zenuwstelsel (rustmodus) wordt geactiveerd.</li>\n<li><strong>Box breathing</strong> – adem 4 seconden in, houd 4 vast, adem 4 uit, houd 4 vast. Ideaal om stress direct te verlagen.</li>\n<li><strong>Diepe zuchten</strong> – een paar keer bewust volledig uitademen helpt letterlijk spanning én afvalstoffen los te laten.</li>\n</ul>\n\n<p>Ik heb zelf periodes gehad dat ik midden op de dag stopte en gewoon 10 diepe ademhalingen deed. Het voelde misschien simpel, maar mijn energie zakte minder weg en ik voelde me helderder in mijn hoofd.</p>\n\n<p><strong>👉 Jouw actie:</strong> neem vandaag één ademhalingsoefening en probeer die 5 minuten. Merk hoe je je voelt voor en na. Schrijf het op. Vaak zie je pas het verschil als je het bewust noteert.</p>\n\n<p>In de volgende les gaan we deze levensstijl-pijler afronden met misschien wel de krachtigste van allemaal: ontspanning en herstel. Want zonder rust kan je lichaam simpelweg niet detoxen.</p>"
-    },
-    {
-      "id": "les-40-relaxation-forgotten-condition-detox",
-      "index": 40,
-      "title": "Les 40: Ontspanning: de vergeten voorwaarde voor detox",
-      "type": "Praktijk",
-      "duration_min": 7,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 40</h2>\n<h3>Ontspanning: de vergeten voorwaarde voor detox</h3>\n\n<p>Ik herinner me een periode waarin ik continu \"aan\" stond. Lange werkdagen, constant op mijn telefoon, altijd bezig. En toch at ik gezond, sliep ik redelijk en sportte ik. Maar mijn energie bleef laag en mijn lichaam voelde zwaar. Pas later snapte ik waarom: mijn stress-systeem stond permanent aan – en in die stand detox je nauwelijks.</p>\n\n<h4>Waarom stress je detox blokkeert</h4>\n\n<p>Je lichaam kent twee standen:</p>\n\n<ul>\n<li><strong>Fight-or-flight (stressmodus)</strong> → je lichaam bereidt zich voor op actie. Alle energie gaat naar overleven. Detoxprocessen worden op een laag pitje gezet.</li>\n<li><strong>Rest-and-digest (herstelmodus)</strong> → dit is waar magie gebeurt: je spijsvertering werkt optimaal, je lever en nieren hebben de ruimte, je immuunsysteem ruimt op.</li>\n</ul>\n\n<p>Als jij continu in stressmodus leeft, krijgt je lichaam simpelweg geen kans om op te ruimen.</p>\n\n<h4>Ontspanning als detox-tool</h4>\n\n<ul>\n<li><strong>Meditatie of gebed</strong> – 10 minuten stilte per dag verlaagt stresshormonen en opent ruimte voor herstel.</li>\n<li><strong>Wandelen in de natuur</strong> – bewezen effectief om cortisol te verlagen.</li>\n<li><strong>Dagelijks offline moment</strong> – geen schermen, geen prikkels.</li>\n<li><strong>Massage of yoga</strong> – helpt spanning letterlijk los te laten uit je spieren én je zenuwstelsel.</li>\n</ul>\n\n<h4>Mijn ervaring</h4>\n\n<p>Toen ik dagelijks een vast ontspanningsmoment inbouwde – voor mij was dat 's avonds lezen zonder telefoon – merkte ik dat mijn slaap dieper werd en mijn energie overdag stabieler. Het voelde alsof mijn lichaam eindelijk weer ruimte had om schoon te maken.</p>\n\n<p><strong>👉 Jouw actie:</strong> kies vandaag één ontspanningsritueel en maak er een mini-gewoonte van. Het hoeft niet groot te zijn – zelfs 5 minuten diepe ademhaling of journaling kan al wonderen doen.</p>\n\n<p>Met deze les heb je nu de vier levensstijl-pijlers compleet: beweging, zweten, ademhaling en ontspanning. Samen vormen ze de fundering waarop je detox écht tot zijn recht komt.</p>\n\n<p>In het volgende hoofdstuk duiken we opnieuw de wereld van voeding in: hoe je met detox-voeding en slimme supplementen je lichaam actief kunt ondersteunen.</p>"
-    },
-    {
-      "id": "les-41-detox-nutrition-supplements-fuel-cleanup",
-      "index": 41,
-      "title": "Les 41: Detox-voeding & supplementen: brandstof voor je opruimsysteem",
-      "type": "Theorie",
-      "duration_min": 10,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 41</h2>\n<h3>Detox-voeding & supplementen: brandstof voor je opruimsysteem</h3>\n\n<p>Toen ik voor het eerst echt ging letten op detox-voeding, voelde dat in het begin ingewikkeld: zoveel adviezen, zoveel lijstjes. Tot ik besefte dat het eigenlijk heel simpel is. Je lichaam heeft geen extreme diëten nodig, geen dure sapkuren. Het heeft gewoon de juiste brandstof nodig om zijn eigen detoxkracht maximaal te benutten.</p>\n\n<h4>Voeding als medicijn</h4>\n\n<ul>\n<li><strong>Groene bladgroenten</strong> → vol chlorofyl, werkt als een spons die gifstoffen bindt.</li>\n<li><strong>Kruisbloemige groenten</strong> (broccoli, spruitjes, bloemkool) → activeren leverenzymen die toxines neutraliseren.</li>\n<li><strong>Vezels</strong> (havermout, chiazaad, peulvruchten) → binden afvalstoffen in de darmen en zorgen dat ze je lichaam verlaten.</li>\n<li><strong>Bessen & citrusvruchten</strong> → bomvol antioxidanten die cellen beschermen tegen schade door toxines.</li>\n<li><strong>Knoflook & ui</strong> → rijk aan zwavelverbindingen die je lever ondersteunen.</li>\n</ul>\n\n<h4>Supplementen als extra steun</h4>\n\n<p>Soms lukt het niet om alles via voeding binnen te krijgen. Dan kunnen supplementen helpen, mits slim gekozen:</p>\n\n<ul>\n<li><strong>Glutathion</strong> – de \"master antioxidant\", cruciaal voor je lever.</li>\n<li><strong>NAC (N-acetylcysteïne)</strong> – helpt je lichaam glutathion aan te maken.</li>\n<li><strong>Chlorella & spirulina</strong> – krachtige binders van gifstoffen en zware metalen.</li>\n<li><strong>Omega-3 vetzuren</strong> – verminderen ontstekingen die toxines veroorzaken.</li>\n<li><strong>Vitamine C & E</strong> – ondersteunen je immuunsysteem en beschermen tegen oxidatieve stress.</li>\n</ul>\n\n<p>Wat ik zelf ontdekte: je hoeft niet álles tegelijk te nemen. Ik begon simpel – elke dag meer vezels, extra broccoli en een omega-3 supplement. Dat alleen al gaf me binnen weken meer energie en een lichter gevoel.</p>\n\n<h4>Jouw actie</h4>\n\n<p>Kijk vandaag naar je voeding en kies één detox-voedingsmiddel dat je structureel wilt toevoegen. Misschien een smoothie met spinazie en bessen. Misschien vaker broccoli bij je avondeten. Kies iets simpels en houd het vol.</p>\n\n<p>In de volgende les ga ik dieper in op de kracht van vezels – misschien wel de meest onderschatte detox-tool die er bestaat.</p>"
-    },
-    {
-      "id": "les-42-fiber-forgotten-detox-hero",
-      "index": 42,
-      "title": "Les 42: Vezels: de vergeten detoxheld",
-      "type": "Theorie",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 42</h2>\n<h3>Vezels: de vergeten detoxheld</h3>\n\n<p>Ik moet eerlijk zeggen: jarenlang dacht ik bij vezels alleen aan \"goed voor je stoelgang\". Tot ik ontdekte dat vezels misschien wel de krachtigste detox-tool zijn die we hebben. Sindsdien kijk ik nooit meer hetzelfde naar mijn bord.</p>\n\n<h4>Hoe vezels je lichaam helpen ontgiften</h4>\n\n<h5>Binden van gifstoffen</h5>\n<p>Vezels werken als een spons in je darmen. Ze hechten zich aan toxines, zware metalen en resten van pesticiden en zorgen dat die via je ontlasting worden afgevoerd – in plaats van terug je bloed in te lekken.</p>\n\n<h5>Voeden van je darmflora</h5>\n<p>Goede bacteriën in je darmen leven van vezels. Als ze die krijgen, maken ze stoffen (zoals boterzuur) die je darmwand versterken en ontstekingen remmen.</p>\n\n<h5>Stabiele bloedsuiker en hormonen</h5>\n<p>Vezels vertragen de opname van suikers, waardoor je bloedsuikerspiegel stabieler blijft. Dat geeft je lever minder stress en meer ruimte om te detoxen.</p>\n\n<h4>Waar vind je de meeste vezels?</h4>\n\n<ul>\n<li><strong>Groenten</strong> (broccoli, wortels, spinazie, spruitjes)</li>\n<li><strong>Fruit</strong> (appels, bessen, peren, vijgen)</li>\n<li><strong>Peulvruchten</strong> (linzen, kikkererwten, bonen)</li>\n<li><strong>Volkoren producten</strong> (havermout, quinoa, volkoren rijst)</li>\n<li><strong>Zaden & pitten</strong> (chia, lijnzaad, pompoenpitten)</li>\n</ul>\n\n<h4>Hoeveel heb je nodig?</h4>\n\n<p>De meeste mensen halen amper 20 gram per dag, terwijl 35–40 gram ideaal zou zijn. Dat verschil voel je: meer vezels = betere spijsvertering, lichtere ontlasting, minder opgeblazen gevoel en een effectievere detox.</p>\n\n<p>Toen ik mijn ontbijt veranderde van witbrood naar havermout met chia en bessen, merkte ik binnen een week verschil. Mijn energie werd constanter en mijn darmen voelden rustiger.</p>\n\n<p><strong>👉 Jouw actie:</strong> voeg vandaag één extra portie vezels toe aan je voeding. Denk aan een handje bessen, een eetlepel lijnzaad of een extra schep groenten bij het avondeten.</p>\n\n<p>In de volgende les ga ik je meenemen in een andere krachtige bondgenoot: antioxidanten. Dit zijn de \"schilden\" die je cellen beschermen tegen schade door gifstoffen.</p>"
-    },
-    {
-      "id": "les-43-antioxidants-shield-against-toxins",
-      "index": 43,
-      "title": "Les 43: Antioxidanten: je schild tegen toxines",
-      "type": "Theorie",
-      "duration_min": 8,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 43</h2>\n<h3>Antioxidanten: je schild tegen toxines</h3>\n\n<p>Toen ik voor het eerst hoorde over antioxidanten, dacht ik: \"Weer zo'n hippe marketingterm.\" Tot ik begreep wat ze écht doen: antioxidanten zijn letterlijk de schilden die je cellen beschermen tegen de schade die toxines veroorzaken. Sinds dat inzicht zie ik bessen, thee en kruiden niet meer als gewoon eten, maar als dagelijkse bescherming.</p>\n\n<h4>Wat gebeurt er zonder antioxidanten?</h4>\n\n<p>Toxines veroorzaken oxidatieve stress – een soort \"roest\" in je lichaam. Je cellen raken beschadigd door vrije radicalen, waardoor je sneller veroudert, je energie inzakt en je immuunsysteem verzwakt. Antioxidanten neutraliseren die vrije radicalen en houden je cellen veerkrachtig.</p>\n\n<h4>Belangrijkste antioxidanten in voeding</h4>\n\n<ul>\n<li><strong>Vitamine C</strong> – citrusfruit, paprika, kiwi.</li>\n<li><strong>Vitamine E</strong> – noten, zaden, avocado.</li>\n<li><strong>Beta-caroteen</strong> – wortels, zoete aardappel, spinazie.</li>\n<li><strong>Polyfenolen</strong> – bessen, druiven, groene thee, cacao.</li>\n<li><strong>Curcumine</strong> – kurkuma, vooral in combinatie met zwarte peper.</li>\n</ul>\n\n<h4>Hoe je dit praktisch toepast</h4>\n\n<ul>\n<li><strong>Begin de dag met een smoothie vol bessen</strong> → directe antioxidantenboost.</li>\n<li><strong>Drink groene thee in plaats van frisdrank of koffie</strong> → polyfenolen + hydratatie.</li>\n<li><strong>Voeg kurkuma en zwarte peper toe aan je gerechten</strong> → krachtige ontstekingsremmer.</li>\n<li><strong>Eet kleurrijk</strong> → hoe meer kleuren op je bord, hoe meer verschillende antioxidanten je binnenkrijgt.</li>\n</ul>\n\n<p>Wat ik zelf merkte: toen ik mijn voeding rijker maakte aan antioxidanten, voelde mijn energie veel constanter. Geen dipjes halverwege de dag, en mijn huid begon letterlijk meer te stralen. Het klinkt bijna cliché, maar je ziet het verschil écht aan de buitenkant.</p>\n\n<p><strong>👉 Jouw actie:</strong> kies vandaag één antioxidantrijke toevoeging. Misschien een handje blauwe bessen, een kop groene thee, of een schep kurkuma in je soep. Kleine keuzes, grote bescherming.</p>\n\n<p>In de volgende les duiken we in een voedingsstof die vaak vergeten wordt, maar cruciaal is voor detox: zwavelverbindingen – de geheime kracht achter knoflook, ui en broccoli.</p>"
-    },
-    {
-      "id": "les-44-sulfur-compounds-secret-detox-boosters",
-      "index": 44,
-      "title": "Les 44: Zwavelverbindingen: de geheime detox-boosters",
-      "type": "Theorie",
-      "duration_min": 7,
-      "draft": false,
-      "content_html": "<h2>🌱 Les 44</h2>\n<h3>Zwavelverbindingen: de geheime detox-boosters</h3>\n\n<p>De eerste keer dat ik leerde dat knoflook, ui en broccoli echte detoxwapens zijn, dacht ik: \"Serieus? Gewoon die simpele dingen die ik al jaren eet?\" Maar juist dát maakt het zo krachtig. Je hoeft geen exotische superfoods te zoeken – de sleutel ligt vaak gewoon in je keuken.</p>\n\n<h4>Waarom zwavel zo belangrijk is</h4>\n\n<p>Zwavelverbindingen activeren je leverenzymen die gifstoffen onschadelijk maken. Vooral in fase 2 van de leverdetox spelen ze een cruciale rol: daar worden schadelijke stoffen gebonden en klaargezet om via je urine of gal het lichaam te verlaten.</p>\n\n<h4>Belangrijkste bronnen van zwavel</h4>\n\n<ul>\n<li><strong>Knoflook</strong> – bevat allicine, een krachtige stof die je lever ondersteunt.</li>\n<li><strong>Uien, prei & bieslook</strong> – familie van de ui, rijk aan zwavelverbindingen.</li>\n<li><strong>Kruisbloemige groenten</strong> – broccoli, bloemkool, spruitjes, boerenkool.</li>\n<li><strong>Eieren</strong> – vooral het eigeel bevat veel zwavel.</li>\n<li><strong>Mosterdzaad & radijs</strong> – pittige bronnen die vaak vergeten worden.</li>\n</ul>\n\n<h4>Extra voordelen</h4>\n\n<ul>\n<li>Zwavelverbindingen hebben een ontstekingsremmend effect.</li>\n<li>Ze ondersteunen je immuunsysteem.</li>\n<li>Ze helpen bij het neutraliseren van zware metalen in je lichaam.</li>\n</ul>\n\n<p>Wat ik zelf merkte: toen ik elke dag bewuster knoflook en broccoli toevoegde, voelde mijn spijsvertering lichter en mijn energie stabieler. Het is bizar hoe zulke simpele voedingsmiddelen zo'n groot verschil kunnen maken.</p>\n\n<p><strong>👉 Jouw actie:</strong> voeg vandaag één zwavelrijke bron toe aan je maaltijd. Bak bijvoorbeeld knoflook mee in je groenten, eet een eitje of zet broccoli op tafel.</p>\n\n<p>In de volgende les gaan we dit hoofdstuk afronden met een krachtige combinatie: supplementen die je detoxkracht versterken – en hoe je ze slim inzet zonder te overdrijven.</p>"
-    },
-    {
-      "id": "les-45-supplements-extra-support-detox",
-      "index": 45,
-      "title": "Les 45: Supplementen: extra steun voor je detox",
-      "type": "Theorie",
+      "title": "Risico begrijpen zonder angst",
+      "type": "Inzicht",
       "duration_min": 9,
       "draft": false,
-      "content_html": "<h2>🌱 Les 45</h2>\n<h3>Supplementen: extra steun voor je detox</h3>\n\n<p>Toen ik begon met supplementen dacht ik dat ik meteen een hele kast vol nodig had. Maar al snel ontdekte ik dat het niet draait om zoveel mogelijk pillen slikken – het gaat om de juiste keuzes, afgestemd op wat je lichaam écht kan gebruiken. Supplementen zijn geen wondermiddel, maar wel een waardevolle steun in de rug naast voeding en levensstijl.</p>\n\n<h4>De krachtigste detox-supplementen</h4>\n\n<ul>\n<li><strong>Glutathion</strong> – wordt vaak de master antioxidant genoemd. Cruciaal voor je lever om toxines te neutraliseren.</li>\n<li><strong>NAC (N-acetylcysteïne)</strong> – een voorloper van glutathion. Werkt vaak nóg beter omdat je lichaam dit zelf omzet.</li>\n<li><strong>Chlorella & spirulina</strong> – algen die zich binden aan zware metalen en toxines en helpen bij de afvoer.</li>\n<li><strong>Omega-3 vetzuren</strong> – verminderen ontstekingen die gifstoffen in je lichaam veroorzaken.</li>\n<li><strong>Vitamine C & E</strong> – versterken je immuunsysteem en beschermen tegen oxidatieve stress.</li>\n<li><strong>Zink & selenium</strong> – ondersteunen enzymen die betrokken zijn bij detoxprocessen.</li>\n</ul>\n\n<h4>Hoe je slim omgaat met supplementen</h4>\n\n<ul>\n<li><strong>Kies kwaliteit boven kwantiteit</strong> → goedkope varianten bevatten vaak vulstoffen en werken minder goed.</li>\n<li><strong>Start klein</strong> → begin met 1 of 2 supplementen en kijk hoe je lichaam reageert.</li>\n<li><strong>Blijf voeding als basis zien</strong> → supplementen vullen aan, maar vervangen geen groenten, vezels of goede slaap.</li>\n</ul>\n\n<p>Wat ik zelf leerde: toen ik dacht dat ik \"alles\" nodig had, voelde ik me alleen maar overprikkeld en verloor ik overzicht. Pas toen ik terugging naar basics (omega-3 en NAC), merkte ik écht verschil. Meer energie, helderder in mijn hoofd en minder last van dipjes.</p>\n\n<p><strong>�� Jouw actie:</strong> kies één supplement dat past bij jouw huidige situatie. Bijvoorbeeld NAC als je je lever wilt ondersteunen, of omega-3 als je weinig vette vis eet. Bouw van daaruit verder.</p>\n\n<p>Met deze les rond je hoofdstuk 9 af. Je weet nu welke voeding en supplementen je detoxsysteem kracht geven, en hoe je ze stap voor stap in je leven integreert.</p>\n\n<p>In het volgende hoofdstuk gaan we kijken naar een totaal andere invalshoek: je omgeving ontgiften. Want het gaat niet alleen om wat je eet of smeert – ook je lucht, je huis en je spullen kunnen je lichaam belasten of juist ondersteunen.</p>"
+      "lead": "‘Aanwezig’ en ‘gevaarlijk’ betekenen niet hetzelfde. Met vijf eenvoudige vragen lees je nieuws en claims veel scherper.",
+      "opening": [
+        "Wanneer een onderzoek een stof in bloed, moedermelk of drinkwater vindt, is dat belangrijke informatie. Maar het vertelt nog niet automatisch hoeveel gezondheidsschade een individu ondervindt. Daarvoor moeten we weten om welke stof het gaat, hoeveel ervan aanwezig is, hoe die binnenkomt en hoe lang de blootstelling duurt.",
+        "Dit onderscheid is geen reden om zorgen weg te wuiven. Het helpt juist om serieuze risico’s serieus te nemen en spectaculaire marketing te herkennen."
+      ],
+      "sections": [
+        {
+          "title": "De vijf vragen van risicodenken",
+          "paragraphs": [
+            "Stel bij iedere alarmerende kop dezelfde vragen. Eén: welke stof of stofgroep? Twee: welke hoeveelheid? Drie: via welke route? Vier: hoe vaak en hoe lang? Vijf: hoe sterk is het bewijs voor een gezondheidseffect bij mensen? Als een bericht daar niets over zegt, weet je dat de conclusie nog openstaat.",
+            "Een stof kan gevaarlijke eigenschappen hebben, terwijl de werkelijke blootstelling laag is. Andersom kan een klein beetje relevant worden als de stof zeer persistent is en blootstelling jarenlang terugkomt. Daarom spreken deskundigen over gevaar én blootstelling. Risico ontstaat uit de combinatie."
+          ],
+          "bullets": [
+            "Stof: PFAS is een grote familie; leden verschillen van elkaar.",
+            "Dosis: de hoeveelheid maakt vaak een belangrijk verschil.",
+            "Route: inslikken, inademen en huidcontact zijn niet uitwisselbaar.",
+            "Tijd: eenmalig contact is iets anders dan jarenlange herhaling.",
+            "Bewijs: een laboratoriumsignaal is nog geen bewezen effect in het dagelijks leven."
+          ]
+        },
+        {
+          "title": "Waarom onzekerheid niet hetzelfde is als veiligheid",
+          "paragraphs": [
+            "Bij nieuwe of moeilijk meetbare stoffen kan wetenschap nog geen volledig antwoord geven. Dat betekent niet dat er ‘dus niets aan de hand’ is. Het betekent dat voorzorg verstandig kan zijn, vooral wanneer een alternatief eenvoudig, veilig en betaalbaar is.",
+            "Voorzorg heeft ook grenzen. Als angst ervoor zorgt dat je minder groente eet, te weinig drinkt of gevaarlijke supplementen gebruikt, wordt de oplossing zelf een probleem. Een goede voorzorgskeuze verlaagt een plausibele blootstelling zonder een groter nadeel te maken."
+          ],
+          "note": "De beste vraag is vaak niet ‘is dit honderd procent veilig?’, maar ‘wat is onder mijn omstandigheden de verstandigste keuze?’"
+        },
+        {
+          "title": "Maak ruimte tussen informatie en actie",
+          "paragraphs": [
+            "Geef jezelf een korte pauze voordat je een product weggooit of iets duurs bestelt. Zoek de oorspronkelijke bron, controleer of het advies over jouw land en situatie gaat en kijk wie aan de claim verdient.",
+            "Een cursus van hoge kwaliteit maakt je niet afhankelijk van steeds nieuwe waarschuwingen. Hij geeft je een denkkader dat ook werkt bij de volgende stof die in het nieuws komt."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Ontleed één gezondheidsclaim",
+        "time": "12 minuten",
+        "intro": "Kies een nieuwsbericht, socialpost of productclaim over detox of chemische stoffen.",
+        "steps": [
+          "Noteer de exacte claim zonder hem sterker te formuleren.",
+          "Beantwoord de vijf vragen: stof, dosis, route, tijd en bewijs.",
+          "Schrijf op wat zeker is, wat aannemelijk is en wat onbekend blijft.",
+          "Beslis: geen actie, later onderzoeken of een kleine voorzorgsstap."
+        ],
+        "reflection": "Werd de claim sterker of juist zwakker toen je hem precies maakte?"
+      },
+      "remember": [
+        "Aanwezigheid alleen bewijst geen gezondheidsschade.",
+        "Risico hangt af van stof, dosis, route, frequentie en duur.",
+        "Voorzorg is sterk wanneer de stap klein is en geen groter nadeel veroorzaakt."
+      ]
     },
     {
-      "id": "les-46-living-environment-hidden-toxin-source",
-      "index": 46,
-      "title": "Les 46: Je leefomgeving: de verborgen toxinebron",
-      "type": "Theorie",
+      "id": "cr2-les-04-prioriteiten",
+      "index": 4,
+      "title": "Kies wat echt verschil maakt",
+      "type": "Strategie",
       "duration_min": 8,
       "draft": false,
-      "content_html": "<h2>🌱 Les 46</h2>\n<h3>Je leefomgeving: de verborgen toxinebron</h3>\n\n<p>Toen ik dit pad begon, keek ik vooral naar voeding en cosmetica. Maar pas later ontdekte ik dat mijn omgeving minstens zo'n grote rol speelt. De lucht die ik adem, het stof op mijn meubels, de schoonmaakmiddelen in mijn kast – allemaal kleine bronnen die samen een groot verschil maken.</p>\n\n<h4>Hoe je omgeving je belast</h4>\n\n<ul>\n<li><strong>Luchtkwaliteit</strong> → in huis ademen we vaak meer vervuiling in dan buiten, door stof, schimmels en chemische dampen van meubels of verf.</li>\n<li><strong>Huishoudproducten</strong> → schoonmaakmiddelen, luchtverfrissers en kaarsen bevatten vaak vluchtige organische stoffen (VOS) die je longen en lever extra belasten.</li>\n<li><strong>Elektronica & meubels</strong> → veel plastics, coatings en schuimen laten weekmakers of vlamvertragers los die je huisstof binnendringen.</li>\n<li><strong>Water</strong> → kraanwater kan resten van PFAS, pesticiden en zware metalen bevatten.</li>\n</ul>\n\n<p>Wat ik zelf ontdekte: het stof dat ik elke week van mijn kast veegde, was niet zomaar stof. Het zat vol met microplastics en chemische resten van meubels en elektronica. Dat maakte me veel bewuster van de lucht die ik dagelijks inadem.</p>\n\n<h4>Waarom dit belangrijk is</h4>\n\n<p>Je kunt nog zo gezond eten en bewegen, maar als je omgeving vol toxines zit, blijft je lichaam in de overlevingsstand. Door je omgeving te \"ontgiften\", verlaag je de constante druk – en geef je je lijf de ruimte om écht te herstellen.</p>\n\n<p><strong>👉 Jouw opdracht:</strong> loop vandaag eens één kamer in je huis rond en stel jezelf de vraag: \"Welke producten hier zouden mijn lucht of mijn huid kunnen belasten?\" Noteer 2 dingen die je opvallen. Alleen al dit bewustzijn zet verandering in gang.</p>\n\n<p>In de volgende les gaan we praktisch worden: hoe je je huis schoner en toxinevrijer maakt – zonder dat het ingewikkeld of duur hoeft te zijn.</p>"
+      "lead": "Je hoeft niet alles tegelijk aan te pakken. Met een simpele impactladder bouw je een reset die ook na vier weken blijft staan.",
+      "opening": [
+        "De markt rondom ‘toxinevrij’ verdient aan urgentie. Alles moet nu vervangen, gefilterd of geslikt worden. In werkelijkheid ontstaat duurzame winst meestal uit saaie, herhaalbare keuzes: eten niet onnodig in plastic verhitten, goed ventileren, stof verminderen en verzorging eenvoudig houden.",
+        "Vandaag vertaal je je blootstellingskaart naar drie niveaus. Daardoor weet je straks bij ieder nieuw inzicht wat je ermee moet doen."
+      ],
+      "sections": [
+        {
+          "title": "De drie treden van jouw impactladder",
+          "paragraphs": [
+            "Trede één is direct en gratis: anders gebruiken, ventileren, handen wassen of een spray weglaten. Trede twee is vervangen wanneer iets op is of versleten raakt. Trede drie vraagt onderzoek, geld of professioneel advies en komt alleen aan bod als de vermoedelijke winst dat rechtvaardigt.",
+            "Deze volgorde beschermt je tegen kostbare symbolische acties. Een verzameling ‘detoxproducten’ kopen terwijl je dagelijks eten in beschadigd plastic verhit, draait de prioriteiten om."
+          ],
+          "bullets": [
+            "Nu doen: gratis, laag risico, vaak herhaalbaar.",
+            "Slim vervangen: pas bij een logisch koopmoment en met duidelijke criteria.",
+            "Eerst onderzoeken: filters, testen, grote verbouwingen of medische trajecten."
+          ]
+        },
+        {
+          "title": "Gebruik de 80/20-vraag",
+          "paragraphs": [
+            "Vraag: welke paar situaties bepalen waarschijnlijk het grootste deel van mijn vermijdbare blootstelling? Je antwoord hoeft niet wetenschappelijk exact te zijn. Het gaat om de combinatie van frequentie, intensiteit en gemak.",
+            "Voor een gezin kan dat de manier van opwarmen, ventilatie tijdens koken en het aantal geparfumeerde sprays zijn. Voor iemand in een werkplaats kunnen beroepsmaatregelen vele malen belangrijker zijn dan een ander shampoo-merk. Persoonlijke context wint van algemene ranglijstjes."
+          ]
+        },
+        {
+          "title": "Definieer ‘goed genoeg’ vooraf",
+          "paragraphs": [
+            "Zonder eindpunt blijft verbeteren een bodemloze put. Kies daarom per ruimte of thema een standaard. Bijvoorbeeld: heet eten gaat in glas of keramiek; we luchten dagelijks; ik gebruik maximaal drie verzorgingsproducten met parfum; ik koop pas een filter na controle van lokale waterinformatie.",
+            "Goed genoeg is geen gebrek aan ambitie. Het is de grens die voorkomt dat gezondheid een voltijdbaan wordt."
+          ],
+          "note": "Je nieuwe standaard moet op een drukke week uitvoerbaar blijven. Anders is het een tijdelijk project, geen leefstijl."
+        }
+      ],
+      "assignment": {
+        "title": "Bouw je eerste impactladder",
+        "time": "15 minuten",
+        "intro": "Pak je blootstellingskaart uit les 2 en verdeel maximaal negen punten.",
+        "steps": [
+          "Kies drie gratis acties voor ‘nu doen’.",
+          "Kies drie producten voor ‘vervangen wanneer op of versleten’.",
+          "Kies maximaal drie vragen voor ‘eerst onderzoeken’.",
+          "Schrap één punt dat vooral door angst of marketing op je lijst belandde."
+        ],
+        "reflection": "Welke kleine keuze levert waarschijnlijk de meeste herhaling per week op?"
+      },
+      "remember": [
+        "Dagelijkse herhaling weegt vaak zwaarder dan een zeldzame perfecte keuze.",
+        "Gebruik eerst anders, vervang daarna en onderzoek grote uitgaven vooraf.",
+        "Een vooraf gekozen ‘goed genoeg’ beschermt je rust."
+      ]
     },
     {
-      "id": "les-47-house-detox-practical-tips",
-      "index": 47,
-      "title": "Les 47: Je huis detoxen: praktische tips",
+      "id": "cr2-les-05-pfas",
+      "index": 5,
+      "title": "PFAS: wat je moet weten",
+      "type": "Stoffen",
+      "duration_min": 10,
+      "draft": false,
+      "lead": "PFAS zijn hardnekkig en verdienen beleid én aandacht, maar geen lijst met wondermiddelen die beloven ze thuis even op te ruimen.",
+      "opening": [
+        "PFAS is de verzamelnaam voor duizenden door mensen gemaakte stoffen met water-, vet- of vuilafstotende eigenschappen. Ze zijn toegepast in onder meer industriële processen, coatings, textiel, blusschuim en sommige voedselcontactmaterialen. De chemische binding die ze nuttig maakt, zorgt er ook voor dat veel PFAS nauwelijks afbreken.",
+        "Sommige PFAS kunnen zich ophopen in mens en milieu. Onderzoek koppelt blootstelling aan effecten op onder andere het immuunsysteem en de voortplanting, maar stoffen verschillen en risico hangt af van de daadwerkelijke blootstelling."
+      ],
+      "sections": [
+        {
+          "title": "Waarom dit vooral een collectief probleem is",
+          "paragraphs": [
+            "PFAS verspreiden zich via productie, bodem, water en voedselketens. RIVM benadrukt dat individuele consumenten maar beperkt invloed hebben op PFAS in voedsel en drinkwater. Bronaanpak, normen en sanering zijn daarom essentieel. Dat is belangrijk om te horen: jij hoeft een systeemprobleem niet alleen met je boodschappenmand op te lossen.",
+            "Persoonlijke keuzes kunnen vermijdbare bronnen verkleinen, maar ze maken blootstelling niet nul. Het doel is dus verstandig verminderen zonder valse controle te verkopen."
+          ],
+          "bullets": [
+            "Volg lokale waarschuwingen over vis, eieren of moestuinproducten in verontreinigde gebieden.",
+            "Gebruik producten volgens de aanwijzingen en vervang beschadigde anti-aanbakmaterialen op een logisch moment.",
+            "Vraag bij water-, vet- of vuilafstotende producten of de functie werkelijk nodig is.",
+            "Vertrouw niet op ‘PFOA-vrij’ als bewijs dat een product volledig PFAS-vrij is."
+          ]
+        },
+        {
+          "title": "Wat je niet uit een productlabel kunt aflezen",
+          "paragraphs": [
+            "PFAS staan lang niet altijd herkenbaar op een consumentenlabel. Termen als waterdicht, easy-care of stain-resistant zeggen iets over een functie, niet automatisch over de gebruikte chemie. Andersom is niet ieder waterdicht product per definitie een relevante bron voor jou.",
+            "Een bruikbare aanpak is functies beperken. Koop een sterk waterafstotend product wanneer je het echt nodig hebt, niet standaard voor ieder tafelkleed, jasje of cosmeticaproduct. Vraag de fabrikant om een duidelijke PFAS-vrije verklaring wanneer dit belangrijk is."
+          ],
+          "note": "Een ‘vrij van één PFAS’-claim kan een smalle claim zijn. Kijk liever naar een verklaring over de hele PFAS-groep en de bedoelde toepassing."
+        },
+        {
+          "title": "Geen thuisdetox voor PFAS",
+          "paragraphs": [
+            "Er is geen bewezen smoothie, sauna-ritueel of supplement waarmee je PFAS veilig uit je lichaam verwijdert. Medische technieken worden alleen in specifieke onderzoeks- of zorgcontexten beoordeeld en zijn geen doe-het-zelfadvies.",
+            "Je sterkste persoonlijke route blijft: nieuwe vermijdbare blootstelling beperken, algemene gezondheid ondersteunen en officiële adviezen volgen wanneer jouw omgeving aantoonbaar verontreinigd is."
+          ],
+          "warning": "Laat commerciële bloed- of ‘toxinetesten’ alleen uitvoeren als duidelijk is wat de uitslag medisch betekent en welke erkende vervolgstap mogelijk is; een getal zonder handelingsperspectief kan vooral onrust opleveren."
+        }
+      ],
+      "assignment": {
+        "title": "Doe de functietest",
+        "time": "12 minuten",
+        "intro": "Kies vijf spullen met een water-, vet- of vuilafstotende functie.",
+        "steps": [
+          "Noteer hoe vaak je de beschermende functie werkelijk nodig hebt.",
+          "Controleer merk of fabrikant op een concrete PFAS-vrije verklaring.",
+          "Zet ieder product op: behouden, anders gebruiken of later vervangen.",
+          "Controleer of er voor jouw woonplaats officiële lokale adviezen gelden."
+        ],
+        "reflection": "Bij welk product betaal of kies je voor een afstotende functie die je nauwelijks gebruikt?"
+      },
+      "remember": [
+        "PFAS vormen een grote stofgroep; eigenschappen en risico’s verschillen.",
+        "Bronaanpak en beleid zijn belangrijker dan individuele perfectie.",
+        "Er bestaat geen bewezen veilige thuisdetox voor PFAS."
+      ],
+      "sources": [
+        { "label": "RIVM — PFAS", "url": "https://www.rivm.nl/pfas" },
+        { "label": "RIVM — risico’s voor gezondheid en milieu", "url": "https://www.rivm.nl/pfas/risicos-pfas-voor-gezondheid-en-milieu" }
+      ]
+    },
+    {
+      "id": "cr2-les-06-microplastics",
+      "index": 6,
+      "title": "Microplastics: feiten en vragen",
+      "type": "Stoffen",
+      "duration_min": 10,
+      "draft": false,
+      "lead": "Microplastics zijn wijdverspreid. Wat ze op lange termijn precies voor onze gezondheid betekenen, wordt nog volop onderzocht.",
+      "opening": [
+        "Microplastics zijn plasticdeeltjes kleiner dan vijf millimeter; nog kleinere deeltjes worden vaak nanoplastics genoemd. Ze ontstaan bewust klein, bijvoorbeeld als grondstof, of door slijtage en afbraak van grotere plastics. Mensen kunnen deeltjes binnenkrijgen via voedsel, water en ingeademde lucht.",
+        "Onderzoekers hebben plasticdeeltjes in menselijke monsters aangetoond. Dat maakt goede wetenschap urgent, maar de betekenis voor gezondheid is nog niet volledig duidelijk. Meetmethoden, grootte, vorm en samenstelling verschillen, waardoor spectaculaire cijfers niet altijd rechtstreeks vergelijkbaar zijn."
+      ],
+      "sections": [
+        {
+          "title": "Waar de dagelijkse blootstelling kan ontstaan",
+          "paragraphs": [
+            "Slijtage speelt een grote rol: autobanden, synthetisch textiel, verf en grotere plastic voorwerpen verliezen deeltjes. Binnenshuis kunnen stof en vezels bijdragen. In de keuken kan slijtage van materialen of onjuist gebruik extra contact geven, vooral bij hitte en beschadiging.",
+            "Je kunt niet ieder deeltje vermijden. Wel kun je onnodige slijtage en verspreiding beperken en algemene stofblootstelling verminderen."
+          ],
+          "bullets": [
+            "Verhit eten bij voorkeur niet in plastic tenzij het product daar expliciet voor bedoeld en onbeschadigd is.",
+            "Vervang sterk gekraste plastic snijplanken of bakjes bij het normale vervangmoment.",
+            "Ventileer, stofzuig gericht en neem gladde oppervlakken vochtig af.",
+            "Was synthetische kleding alleen wanneer nodig en volg onderhoudsinstructies zodat slijtage beperkt blijft."
+          ]
+        },
+        {
+          "title": "Pas op voor precieze maar onbewezen claims",
+          "paragraphs": [
+            "Claims zoals ‘je eet iedere week een creditcard’ zijn pakkend, maar zulke omrekeningen berusten op aannames en zijn niet geschikt als persoonlijke dosis. Ook een foto van deeltjes zegt niets zonder betrouwbare monstername en analyse.",
+            "Een eerlijk antwoord kan dus tegelijk zijn: microplastics zijn echt en wijdverspreid, we moeten uitstoot verminderen, en de precieze langetermijneffecten voor mensen zijn nog onzeker. Die drie uitspraken botsen niet met elkaar."
+          ],
+          "note": "Onzekerheid is geen uitnodiging tot passiviteit; het is een reden om proportionele, laag-risico maatregelen te kiezen."
+        },
+        {
+          "title": "Denk in minder slijtage, niet in nul plastic",
+          "paragraphs": [
+            "Plastic heeft ook nuttige functies, bijvoorbeeld voor voedselveiligheid, medische toepassingen en een lager productgewicht. Een totale ban in je eigen leven is daarom niet automatisch gezonder of duurzamer.",
+            "Richt je op direct voedselcontact bij hitte, beschadigde materialen, onnodige wegwerpitems en stof. Dat zijn begrijpelijke aangrijpingspunten zonder te doen alsof je je omgeving volledig kunt zuiveren."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Vind drie slijtagemomenten",
+        "time": "10 minuten",
+        "intro": "Loop door keuken, kledingkast en woonkamer en zoek geen plastic, maar slijtage.",
+        "steps": [
+          "Controleer één snijplank, één bewaarbakje en één vaak gedragen synthetisch kledingstuk.",
+          "Noteer waar krassen, pluizen of warmte samenkomen met veel gebruik.",
+          "Kies één andere gebruikswijze die niets kost.",
+          "Zet alleen ernstig beschadigde spullen op je vervanglijst."
+        ],
+        "reflection": "Welke aanpassing vermindert herhaalde slijtage zonder dat je een compleet materiaal hoeft te verbannen?"
+      },
+      "remember": [
+        "Microplastics komen via voedsel, water en lucht binnen.",
+        "De precieze langetermijneffecten bij mensen zijn nog onzeker.",
+        "Minder hitte, slijtage en stof is een nuchtere voorzorgsroute."
+      ],
+      "sources": [
+        { "label": "RIVM — plastics en gezondheid", "url": "https://www.rivm.nl/plastics/gevolgen-gezondheid" },
+        { "label": "WHO — Dietary and inhalation exposure to nano- and microplastic particles", "url": "https://www.who.int/publications/i/item/9789240054608" }
+      ]
+    },
+    {
+      "id": "cr2-les-07-bisfenolen",
+      "index": 7,
+      "title": "BPA & andere bisfenolen",
+      "type": "Stoffen",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "BPA is bekend, maar ‘BPA-vrij’ vertelt niet automatisch welk alternatief is gebruikt of hoe je het product moet behandelen.",
+      "opening": [
+        "Bisfenol A, beter bekend als BPA, is gebruikt bij de productie van bepaalde harde kunststoffen en harslagen in voedselcontactmaterialen. Kleine hoeveelheden kunnen vanuit materiaal naar eten of drinken migreren. Warmte, beschadiging, tijd en het soort voedsel kunnen daarbij relevant zijn.",
+        "Vanwege zorgen over gezondheid heeft de Europese Unie het gebruik van BPA in voedselcontactmaterialen verder beperkt en in december 2024 een verbod aangenomen met overgangstermijnen en specifieke uitzonderingen. Dat is geruststellende systeemactie, maar bestaande en geïmporteerde producten vragen nog steeds verstandig gebruik."
+      ],
+      "sections": [
+        {
+          "title": "Waarom alleen ‘BPA-vrij’ te smal is",
+          "paragraphs": [
+            "Een BPA-vrij product bevat volgens de claim geen BPA, maar kan een ander bisfenol of ander materiaal gebruiken. Zo’n alternatief is niet automatisch slechter, maar ook niet uitsluitend op basis van de voorkant van een verpakking bewezen beter.",
+            "Kijk daarom eerst naar gebruik. Voor koud en kort contact is de situatie anders dan dagelijks opwarmen. Glas, roestvrij staal of keramiek zijn praktische alternatieven wanneer je heet eten bewaart of vaak opwarmt."
+          ],
+          "bullets": [
+            "Volg temperatuur- en magnetroninstructies van de fabrikant.",
+            "Gebruik beschadigde of vervormde bakken niet voor heet voedsel.",
+            "Laat heet eten zo mogelijk afkoelen voordat het een kunststof verpakking in gaat.",
+            "Gebruik kassabonnen niet als speelgoed en was handen voor eten na veelvuldig contact."
+          ]
+        },
+        {
+          "title": "Thermisch papier is een ander contactmoment",
+          "paragraphs": [
+            "Bisfenolen zijn ook toegepast in thermisch papier, zoals sommige kassabonnen. Europese regels hebben BPA daar sterk beperkt, maar vervangende ontwikkelaars kunnen worden gebruikt. Voor de meeste mensen is kort contact geen reden voor paniek.",
+            "Werk je dagelijks met veel bonnen, dan is blootstelling herhaald. Vraag naar digitale bonnen, bewaar papier apart van voedsel en stop bonnen niet los in een tas bij eten. Werkmaatregelen zijn dan relevanter dan obsessief handen wassen na één aankoop."
+          ]
+        },
+        {
+          "title": "De materiaalvraag komt na de gebruiksvraag",
+          "paragraphs": [
+            "Geen enkel materiaal is zonder voor- en nadelen. Glas kan breken, staal kan niet in de magnetron en blik voorkomt voedselverspilling. De beste keuze hangt af van functie, staat en gebruik.",
+            "Maak daarom geen ‘goed materiaal, fout materiaal’-lijst. Maak een gebruiksstandaard: heet en vet voedsel zo veel mogelijk in glas, keramiek of geschikt staal; plastic alleen volgens instructies en zonder zichtbare schade."
+          ],
+          "note": "Gebruik is vaak sneller aan te passen dan je hele voorraadkast, en levert direct herhaling op."
+        }
+      ],
+      "assignment": {
+        "title": "Controleer je drie warmste contactmomenten",
+        "time": "10 minuten",
+        "intro": "Denk aan magnetron, afhaalmaaltijd, koffie, vaatwasser en heet restje.",
+        "steps": [
+          "Kies de drie momenten waarop warmte en voedselcontact samenkomen.",
+          "Controleer de gebruiksinstructie en de staat van het materiaal.",
+          "Verander één routine vandaag, bijvoorbeeld overpakken vóór opwarmen.",
+          "Noteer één item dat je pas vervangt wanneer het versleten is."
+        ],
+        "reflection": "Welke routine kun je aanpassen zonder één nieuw product te kopen?"
+      },
+      "remember": [
+        "BPA kan vanuit voedselcontactmateriaal in kleine hoeveelheden migreren.",
+        "‘BPA-vrij’ is geen volledige veiligheidsbeoordeling.",
+        "Warmte, schade en gebruiksinstructies zijn praktische beslisfactoren."
+      ],
+      "sources": [
+        { "label": "EFSA — Bisphenol A", "url": "https://www.efsa.europa.eu/en/topics/topic/bisphenol" }
+      ]
+    },
+    {
+      "id": "cr2-les-08-ftalaten-parabenen",
+      "index": 8,
+      "title": "Ftalaten & parabenen",
+      "type": "Stoffen",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "Deze groepen worden vaak in één alarmerende zin genoemd, terwijl hun functies, routes en regels duidelijk van elkaar verschillen.",
+      "opening": [
+        "Ftalaten zijn weekmakers: ze maken sommige kunststoffen soepel en kunnen ook in andere toepassingen voorkomen. Parabenen zijn conserveermiddelen die onder meer cosmetica beschermen tegen groei van bacteriën en schimmels. Ze delen dus geen functie, ook al verschijnen ze vaak samen op ‘vrij van’-labels.",
+        "Binnen iedere groep bestaan verschillende stoffen. Sommige toepassingen zijn verboden of beperkt; andere zijn onder voorwaarden toegestaan. Een familienaam is daarom geen volledige risicoanalyse."
+      ],
+      "sections": [
+        {
+          "title": "Ftalaten: let op zacht plastic en context",
+          "paragraphs": [
+            "Ftalaten kunnen uit materiaal vrijkomen omdat ze niet altijd chemisch vastzitten aan het plastic. Blootstelling kan via voedsel, huisstof en consumentenproducten plaatsvinden. Europese regels beperken meerdere ftalaten in speelgoed, kinderartikelen en andere toepassingen.",
+            "Voor thuis is het nuttiger om lang en intensief contact te bekijken dan ieder zacht plastic voorwerp verdacht te maken. Verwarm geen eten in zacht of onbekend plastic, laat kinderen niet op niet-voedselgeschikte kunststof kauwen en ventileer bij nieuwe sterk ruikende materialen."
+          ],
+          "bullets": [
+            "Kies voedselcontactproducten met duidelijke gebruiksinstructies.",
+            "Was nieuw textiel of sterk ruikende producten volgens het etiket vóór intensief gebruik.",
+            "Vervang oud, plakkerig of afbrokkelend zacht plastic.",
+            "Beperk huisstof met ventileren, stofzuigen en vochtig afnemen."
+          ]
+        },
+        {
+          "title": "Parabenen: conserveren heeft ook een functie",
+          "paragraphs": [
+            "Conserveermiddelen voorkomen dat een product tijdens gebruik een voedingsbodem voor micro-organismen wordt. ‘Parabeenvrij’ betekent daarom niet automatisch veiliger; een alternatief conserveermiddel kan andere nadelen hebben en ongeconserveerde waterige zelfmaakcosmetica kan bederven.",
+            "Gebruik cosmetica binnen de houdbaarheid, deel potjes niet onnodig, houd vingers schoon en gooi een product weg als geur, kleur of structuur opvallend verandert. Minder producten gebruiken verlaagt tegelijk het aantal ingrediënten waaraan je huid wordt blootgesteld."
+          ],
+          "note": "Een korte ingrediëntenlijst kan overzicht geven, maar ‘natuurlijk’ en ‘chemisch’ zijn geen kwaliteitskeurmerken."
+        },
+        {
+          "title": "Kies op functie, niet op angstwoord",
+          "paragraphs": [
+            "Een bodylotion die je dagelijks over je hele lichaam gebruikt verdient meer aandacht dan een product dat je maandelijks kort afspoelt. Een product dat irritatie geeft, stop je ongeacht de marketingclaim.",
+            "Kies eenvoudige producten die doen wat je nodig hebt, koop geen voorraad uit onrust en verander één categorie tegelijk. Zo kun je ook merken wat voor jouw huid prettig werkt."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Doe een labelvergelijking",
+        "time": "15 minuten",
+        "intro": "Leg twee verzorgingsproducten met dezelfde functie naast elkaar.",
+        "steps": [
+          "Vergelijk gebruik, ingrediënten, houdbaarheid en waarschuwingen.",
+          "Omcirkel marketingwoorden die niets zeggen over de volledige samenstelling.",
+          "Bepaal welk product je werkelijk nodig hebt en hoe vaak je het gebruikt.",
+          "Kies één categorie waarin ‘minder producten’ jouw standaard wordt."
+        ],
+        "reflection": "Koos je eerder op een volledige afweging of vooral op één ‘vrij van’-claim?"
+      },
+      "remember": [
+        "Ftalaten zijn weekmakers; parabenen zijn conserveermiddelen.",
+        "Stoffen binnen één groep kunnen verschillend gereguleerd en beoordeeld zijn.",
+        "Parabeenvrij is niet automatisch veiliger of beter houdbaar."
+      ]
+    },
+    {
+      "id": "cr2-les-09-pesticiden",
+      "index": 9,
+      "title": "Pesticiden zonder paniek",
+      "type": "Stoffen",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "De gezondheidswinst van groente en fruit blijft groter dan het geschatte risico van resten. Slim kiezen betekent dus: blijven eten én praktisch verminderen.",
+      "opening": [
+        "Gewasbeschermingsmiddelen helpen ziekten en plagen beheersen. Resten kunnen op of in voedsel achterblijven en daarvoor gelden wettelijke limieten en controles. Dat systeem is niet hetzelfde als nul blootstelling, maar een aangetroffen meetwaarde betekent ook niet automatisch dat een product onveilig is.",
+        "Het belangrijkste anker: stop niet met groente en fruit uit angst voor resten. Voedingscentrum benadrukt dat de gezondheidsvoordelen zwaarder wegen dan de huidige ingeschatte risico’s."
+      ],
+      "sections": [
+        {
+          "title": "Wat wassen wel en niet doet",
+          "paragraphs": [
+            "Wassen onder stromend water verwijdert vuil, micro-organismen en een deel van stoffen op het oppervlak. Het verwijdert niet alle resten, zeker niet wanneer een middel in het gewas is opgenomen. Toch is wassen een eenvoudige, zinvolle gewoonte.",
+            "Gebruik geen zeep of schoonmaakmiddel op groente en fruit; die producten zijn niet bedoeld om in te nemen. Schillen kan sommige oppervlakteresten verminderen, maar verwijdert ook vezels en voedingsstoffen en is niet standaard nodig."
+          ],
+          "bullets": [
+            "Was groente en fruit onder stromend water en droog kwetsbare producten schoon af.",
+            "Eet gevarieerd; variatie spreidt zowel voedingsstoffen als mogelijke blootstelling.",
+            "Verwijder beschadigde of beschimmelde delen ruim en bewaar producten passend.",
+            "Volg officiële adviezen bij lokale moestuin- of bodemverontreiniging."
+          ]
+        },
+        {
+          "title": "Biologisch is een keuze, geen toelating tot gezond eten",
+          "paragraphs": [
+            "Biologische teelt gebruikt andere regels en een beperkter pakket middelen, maar ‘biologisch’ betekent niet zonder gewasbescherming of zonder milieubelasting. Gewone producten blijven een gezonde keuze.",
+            "Als je budget beperkt is, besteed het dan niet ten koste van de hoeveelheid en variatie aan groente en fruit. Koop seizoensproducten, diepvriesgroente zonder onnodige toevoegingen en aanbiedingen die je daadwerkelijk opeet."
+          ],
+          "note": "Een betaalbare paprika die je eet is waardevoller dan een biologische paprika die je uit angst niet koopt."
+        },
+        {
+          "title": "Pas op voor detoxclaims rondom pesticiden",
+          "paragraphs": [
+            "Poeders, druppels en sapkuren kunnen niet aantoonbaar alle pesticiden uit je lichaam verwijderen. Je lichaam verwerkt en scheidt veel stoffen via normale fysiologische routes uit; andere stoffen gedragen zich anders. Eén universele ‘detoxbooster’ past niet bij die werkelijkheid.",
+            "Richt je op bronkeuzes, voedselveiligheid en een voedzaam patroon. Dat klinkt minder spectaculair, maar het is betrouwbaarder."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Bouw een betaalbare groenteroutine",
+        "time": "12 minuten",
+        "intro": "Plan voor de komende drie dagen zonder je budget of eetplezier te saboteren.",
+        "steps": [
+          "Kies vijf verschillende kleuren groente of fruit.",
+          "Bepaal wat vers, diepvries of uit pot praktisch is.",
+          "Zet wassen en bewaren meteen in je keukenroutine.",
+          "Kies alleen biologisch waar jij daar ruimte en een duidelijke reden voor hebt."
+        ],
+        "reflection": "Welke regel helpt je méér groente en fruit te eten in plaats van er banger voor te worden?"
+      },
+      "remember": [
+        "Blijf groente en fruit eten; de voordelen wegen zwaarder.",
+        "Wassen is zinvol, maar verwijdert niet alle mogelijke resten.",
+        "Biologisch kan passen, maar is geen voorwaarde voor een gezond voedingspatroon."
+      ],
+      "sources": [
+        { "label": "Voedingscentrum — bestrijdingsmiddelen", "url": "https://www.voedingscentrum.nl/encyclopedie/bestrijdingsmiddelen.aspx" }
+      ]
+    },
+    {
+      "id": "cr2-les-10-warmte-plastic",
+      "index": 10,
+      "title": "Warmte, plastic & bewaren",
+      "type": "Keuken",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "De meest bruikbare keukenregel is niet ‘nooit plastic’, maar: voorkom onnodige hitte, schade en lang contact.",
+      "opening": [
+        "In de keuken komen materiaal, warmte, vet, zuur en tijd samen. Daardoor is gebruik vaak belangrijker dan het logo op een bakje. Een intact voedselgeschikt product dat koud wordt gebruikt is een andere situatie dan een verkleurde verpakking waarin dagelijks olieachtig eten wordt opgewarmd.",
+        "Je gaat vandaag geen kast leeggooien. Je maakt een heldere scheiding tussen koud bewaren, heet verwerken en versleten materiaal."
+      ],
+      "sections": [
+        {
+          "title": "Vier momenten die aandacht verdienen",
+          "paragraphs": [
+            "Kijk naar opwarmen in de magnetron, gloeiend heet eten overpakken, koken met plastic keukengerei en schoonmaken op hoge temperatuur. Controleer altijd of een product voor die toepassing bedoeld is. Een magnetronsymbool is een gebruiksinstructie, geen belofte dat onbeperkt verhitten zonder slijtage kan.",
+            "Gebruik voor frequent opwarmen bij voorkeur glas of keramiek. Voor meenemen kan roestvrij staal praktisch zijn als je niet ter plaatse hoeft te verwarmen."
+          ],
+          "bullets": [
+            "Schep afhaaleten thuis over vóór je het opnieuw verwarmt.",
+            "Laat zeer heet eten iets afkoelen voordat het in kunststof gaat.",
+            "Gebruik geen bakjes van eenmalige verpakking als permanente magnetronbak.",
+            "Vervang materiaal dat vervormd, diep gekrast, plakkerig of afbrokkelend is."
+          ]
+        },
+        {
+          "title": "Bewaren zonder voedselveiligheid te vergeten",
+          "paragraphs": [
+            "Minder materiaalcontact mag nooit betekenen dat restjes uren op kamertemperatuur blijven staan. Koel bereid eten vlot en bewaar het afgedekt. Gebruik passende porties zodat het sneller afkoelt en je alleen opwarmt wat je eet.",
+            "Glas is prettig omdat je slijtage goed ziet en het weinig geuren opneemt. Maar hergebruik een pot alleen als glas en deksel geschikt en onbeschadigd zijn; niet ieder verkoopdeksel is ontworpen voor eindeloos gebruik."
+          ],
+          "note": "Voedselveilig bewaren heeft voorrang op een theoretische materiaaloptimalisatie."
+        },
+        {
+          "title": "Maak één vaste opwarmroute",
+          "paragraphs": [
+            "Leg het geschikte bord of bakje op een vaste plek. Als de veilige keuze meer handelingen kost dan de oude, verdwijnt hij op drukke dagen. Gedrag volgt inrichting.",
+            "Denk ook aan werk en onderweg. Een extra keramisch bord op kantoor kan meer effect hebben dan tien nieuwe bakjes thuis."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "De hittecheck",
+        "time": "15 minuten",
+        "intro": "Leg alle spullen die je gebruikt voor heet eten of drinken bij elkaar.",
+        "steps": [
+          "Controleer materiaal, schade en gebruiksinstructies.",
+          "Maak drie stapels: geschikt, alleen koud gebruiken en vervangen wanneer nodig.",
+          "Richt één vaste opwarmplek in met glas of keramiek.",
+          "Schrijf je nieuwe keukenregel in één korte zin op."
+        ],
+        "reflection": "Waar maakte gemak het tot nu toe waarschijnlijker dat je ongeschikt materiaal bleef verhitten?"
+      },
+      "remember": [
+        "Warmte, schade, vet en contactduur bepalen samen de gebruikssituatie.",
+        "Glas en keramiek zijn handige opties voor vaak opwarmen.",
+        "Goede voedselveiligheid blijft altijd de basis."
+      ]
+    },
+    {
+      "id": "cr2-les-11-drinkwater",
+      "index": 11,
+      "title": "Drinkwater met gezond verstand",
+      "type": "Keuken",
+      "duration_min": 10,
+      "draft": false,
+      "lead": "Een filter is geen automatisch bewijs van schoner of gezonder water. Begin met lokale feiten, een concreet doel en goed onderhoud.",
+      "opening": [
+        "Nederlands kraanwater wordt streng gecontroleerd. Tegelijk zijn PFAS en andere stoffen onderwerp van normen, monitoring en verbetering. Dat kan twee waarheden tegelijk opleveren: kraanwater is een betrouwbare basis én bronaanpak blijft nodig om ongewenste stoffen verder terug te dringen.",
+        "Wie vanuit onrust direct een willekeurig filter koopt, kan geld verspillen of door slecht onderhoud juist de waterkwaliteit verslechteren."
+      ],
+      "sections": [
+        {
+          "title": "Begin bij je waterbedrijf en lokale situatie",
+          "paragraphs": [
+            "Zoek het actuele kwaliteitsrapport van je drinkwaterbedrijf en eventuele adviezen van gemeente, GGD of RIVM. Woon je in een gebied met particuliere bron, oude leidingen of bekende verontreiniging, dan kan je situatie afwijken van het landelijke beeld.",
+            "Laat de kraan na langere stilstand kort doorlopen tot het water fris aanvoelt. Gebruik koud kraanwater voor drinken en koken; warm water uit leidingen heeft langer contact met installatieonderdelen gehad."
+          ],
+          "bullets": [
+            "Gebruik koud water voor koffie, thee en koken en verwarm het daarna.",
+            "Maak kranen en herbruikbare flessen regelmatig schoon.",
+            "Volg een officieel kook- of drinkadvies onmiddellijk als dat lokaal wordt afgegeven.",
+            "Laat alleen gericht testen wanneer er een concrete aanleiding en betrouwbare methode is."
+          ]
+        },
+        {
+          "title": "Als je een filter overweegt",
+          "paragraphs": [
+            "Definieer eerst welke stof je wilt verminderen. Zoek daarna onafhankelijke certificering of testgegevens voor precies die stof, onder omstandigheden die lijken op thuisgebruik. ‘Verbetert smaak’ is geen PFAS-claim en één laboratoriumpercentage vertelt weinig zonder capaciteit en vervangmoment.",
+            "Een filterpatroon raakt verzadigd en systemen kunnen microbiologisch vervuilen. Noteer vervangdata, volg spoel- en onderhoudsinstructies en stop als je dat onderhoud niet consequent kunt uitvoeren."
+          ],
+          "warning": "Gebruik geen marketingtest of verkoper als enige bron voor een grote filteraankoop. Controleer doelstof, certificering, capaciteit, onderhoud en totale kosten."
+        },
+        {
+          "title": "Flessenwater is geen universele oplossing",
+          "paragraphs": [
+            "Flessenwater verschilt per bron en verpakking, kost meer en veroorzaakt transport en afval. Het is niet automatisch vrij van microplastics of andere stoffen. Gebruik het wanneer omstandigheden dat vragen, niet als reflex op een algemene angstclaim.",
+            "Hydratatie blijft belangrijk. Minder drinken om mogelijke verontreiniging te vermijden is geen verstandige risicoruil."
+          ],
+          "note": "De veiligste beslissing begint bij jouw lokale waterinformatie, niet bij het hardste online verhaal."
+        }
+      ],
+      "assignment": {
+        "title": "Maak je waterbesluit",
+        "time": "20 minuten",
+        "intro": "Zoek het actuele kwaliteitsrapport voor jouw postcodegebied.",
+        "steps": [
+          "Noteer welke organisatie jouw water levert en welke actuele informatie zij geeft.",
+          "Schrijf op of er een lokale waarschuwing of bijzondere woningsituatie is.",
+          "Als je al filtert: noteer doelstof, patroon, laatste vervanging en onderhoud.",
+          "Beslis: kraanroutine verbeteren, gerichter onderzoeken of niets wijzigen."
+        ],
+        "reflection": "Is jouw waterkeuze gebaseerd op lokale gegevens of vooral op algemene onrust?"
+      },
+      "remember": [
+        "Begin met actuele lokale waterinformatie.",
+        "Een filter moet aantoonbaar passen bij een doelstof en goed worden onderhouden.",
+        "Flessenwater is niet automatisch schoner of vrij van microplastics."
+      ],
+      "sources": [
+        { "label": "RIVM — PFAS in drinkwater", "url": "https://www.rivm.nl/pfas/drinkwater" }
+      ]
+    },
+    {
+      "id": "cr2-les-12-boodschappen",
+      "index": 12,
+      "title": "Slim boodschappen doen",
+      "type": "Keuken",
+      "duration_min": 8,
+      "draft": false,
+      "lead": "Je winkelwagen hoeft geen laboratorium te worden. Een paar vaste beslisregels geven meer rust dan elk etiket eindeloos uitpluizen.",
+      "opening": [
+        "In de supermarkt komen voeding, verpakking, budget en tijd samen. Als je iedere aankoop als veiligheidsproef behandelt, houd je het niet vol. Daarom werk je met defaults: keuzes die meestal goed genoeg zijn en alleen bij een bijzondere situatie extra onderzoek vragen.",
+        "Voedingskwaliteit blijft de basis. Een minimaal verpakte snack is niet ineens voedzaam en een verpakte volkorenmaaltijd is niet automatisch een slechte keuze."
+      ],
+      "sections": [
+        {
+          "title": "Bouw vijf rustige winkelregels",
+          "paragraphs": [
+            "Kies vooral producten die je helpen gevarieerd en volwaardig te eten. Geef bij gelijkwaardige opties de voorkeur aan minder onnodige verpakking, een verpakking die bij het gebruik past en porties die je opmaakt. Daarmee beperk je materiaalcontact én voedselverspilling.",
+            "Voor producten die je thuis gaat verwarmen, telt de thuisroutine meer dan de winkelindruk. Plan dat je afhaal- of kant-en-klaarvoeding voor verwarmen overpakt wanneer de verpakking daar niet voor bedoeld is."
+          ],
+          "bullets": [
+            "Voeding eerst: groente, fruit, volkorenproducten, peulvruchten, noten en passende eiwitbronnen.",
+            "Variatie boven fixatie op één ‘superfood’ of één vermeende probleemgroep.",
+            "Verpakking passend bij functie en bewaartijd.",
+            "Geen ‘detox’-aankoop zonder concrete werkzame claim en veiligheidsbasis.",
+            "Koop hoeveelheden die je daadwerkelijk gebruikt."
+          ]
+        },
+        {
+          "title": "Lees claims van buiten naar binnen",
+          "paragraphs": [
+            "De voorkant verkoopt; de achterkant specificeert. Kijk eerst wat het product is, hoe je het gebruikt en wat de ingrediënten en bewaarinstructies zeggen. Claims als ‘clean’, ‘natural’ en ‘toxinevrij’ hebben zonder precieze definitie weinig informatiewaarde.",
+            "Een betrouwbare claim zegt wat afwezig of getest is, volgens welke grens en door wie. Zelfs dan blijft de rest van het product relevant."
+          ],
+          "note": "Een product zonder angstmarketing verdient vaak meer vertrouwen dan een product dat eerst een probleem uitvergroot en daarna zichzelf als oplossing verkoopt."
+        },
+        {
+          "title": "Gebruik budget als ontwerpeis",
+          "paragraphs": [
+            "Een reset die je financieel onder druk zet is niet duurzaam. Kies maximaal één categorie waarin je bewust meer betaalt, bijvoorbeeld vaak gebruikt warm voedselcontact of een verzorgingsproduct voor gevoelige huid.",
+            "Voor de rest gebruik je gedrag: wassen, variëren, overpakken, ventileren en goed bewaren. Veel sterke maatregelen kosten weinig of niets."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "De tien-productenproef",
+        "time": "15 minuten",
+        "intro": "Kijk naar je laatste bon of open je vaste online boodschappenlijst.",
+        "steps": [
+          "Selecteer tien producten die je bijna iedere week koopt.",
+          "Beoordeel per product voeding, verpakking, gebruik en verspilling.",
+          "Kies twee defaults die je voortaan zonder extra denkwerk bestelt.",
+          "Schrap één duur ‘gezondheidsproduct’ zonder duidelijke toegevoegde waarde."
+        ],
+        "reflection": "Welke vaste keuze geeft je de meeste rust én herhaling?"
+      },
+      "remember": [
+        "Voedingskwaliteit blijft belangrijker dan verpakkingsperfectie.",
+        "Defaults verminderen keuzestress en maken gezond gedrag herhaalbaar.",
+        "‘Clean’ en ‘toxinevrij’ zijn zonder definitie vooral marketingwoorden."
+      ]
+    },
+    {
+      "id": "cr2-les-13-keukenreset",
+      "index": 13,
+      "title": "Jouw keukenreset",
       "type": "Praktijk",
       "duration_min": 10,
       "draft": false,
-      "content_html": "<h2>🌱 Les 47</h2>\n<h3>Je huis detoxen: praktische tips</h3>\n\n<p>Toen ik mijn huis voor het eerst kritisch bekeek, voelde het alsof ik in een chemisch magazijn woonde. Geurkaarsen, schoonmaaksprays, luchtverfrissers, plastic bakjes, oude meubels – allemaal bronnen die ongemerkt mijn lucht en huid belastten. Het mooie? Je hoeft geen compleet nieuw huis te kopen om verschil te maken. Kleine aanpassingen hebben al een groot effect.</p>\n\n<h4>1. Luchtkwaliteit verbeteren</h4>\n\n<ul>\n<li><strong>Zet dagelijks ramen open</strong> – frisse lucht vermindert ophoping van VOS (vluchtige organische stoffen).</li>\n<li><strong>Zet planten neer</strong> (bijv. lepelplant, sansevieria, aloë vera) → natuurlijke luchtfilters.</li>\n<li><strong>Overweeg een luchtreiniger</strong> als je in een stad of langs een drukke weg woont.</li>\n</ul>\n\n<h4>2. Schoonmaakmiddelen</h4>\n\n<ul>\n<li><strong>Vermijd agressieve sprays</strong> vol chemicaliën.</li>\n<li><strong>Gebruik natuurlijke alternatieven:</strong> azijn, baking soda, citroen en groene zeep. Ze reinigen net zo goed.</li>\n<li><strong>Weg met luchtverfrissers</strong> en \"chemische geurtjes\" → zet een raam open of gebruik etherische olie.</li>\n</ul>\n\n<h4>3. Meubels & textiel</h4>\n\n<ul>\n<li><strong>Stofzuig en dweil regelmatig</strong> – stof bevat vaak microplastics en chemicaliën.</li>\n<li><strong>Was nieuwe kleren en textiel vóór gebruik</strong> om resten van productiechemicaliën weg te spoelen.</li>\n<li><strong>Kies waar mogelijk voor hout, katoen en wol</strong> in plaats van kunststoffen en coatings.</li>\n</ul>\n\n<h4>4. Water</h4>\n\n<ul>\n<li><strong>Gebruik een waterfilter</strong> dat PFAS, pesticiden en zware metalen kan verminderen.</li>\n<li><strong>Zet drinken in glas of RVS</strong> in plaats van plastic kannen of flessen.</li>\n</ul>\n\n<p>Toen ik zelf overstapte op natuurlijke schoonmaakmiddelen en een waterfilter, voelde mijn huis direct anders. Frisser, lichter, en vooral: mijn lichaam leek meer ademruimte te krijgen.</p>\n\n<p><strong>👉 Jouw actie:</strong> kies vandaag één stap om je huis lichter te maken. Misschien een kamer luchten, je schoonmaakmiddelen vervangen of je waterfilter opzoeken. Het hoeft niet groot – consistentie telt.</p>\n\n<p>In de volgende les ga ik je meenemen naar een verrassend detail: stof in huis. Want dat is misschien wel één van de grootste verborgen bronnen van toxines waar niemand aan denkt.</p>"
+      "lead": "Vandaag voeg je alles samen tot een keuken die de verstandige keuze makkelijk maakt, zonder perfecte voorraadkast of koopwoede.",
+      "opening": [
+        "Een keukenreset is geen fotoshoot. Het doel is dat jij op een drukke avond automatisch het juiste bakje pakt, tijdens koken ventileert en restjes veilig bewaart. Inrichting wint van wilskracht.",
+        "Werk in vier zones: bereiden, verhitten, bewaren en drinken. Per zone maak je één standaard en één vervanglijst."
+      ],
+      "sections": [
+        {
+          "title": "Bereiden en verhitten",
+          "paragraphs": [
+            "Controleer snijplanken, spatels, pannen en magnetronmateriaal op schade en geschiktheid. Een kras is niet automatisch een noodsituatie, maar diepe groeven, afbladderende coatings en vervorming zijn duidelijke vervangsignalen.",
+            "Zet ventilatie aan vóórdat damp en rook zich verspreiden. Een afzuigkap die naar buiten afvoert is het effectiefst; anders combineer je afzuiging met een raam wanneer dat veilig kan."
+          ],
+          "bullets": [
+            "Gebruik een passende temperatuur en voorkom dat een lege pan extreem heet wordt.",
+            "Zet glas of keramiek zichtbaar klaar voor opwarmen.",
+            "Maak beschadigd materiaal herkenbaar en gebruik het niet eindeloos uit gewoonte.",
+            "Bewaar een houten of geschikte hittebestendige spatel bij de pannen."
+          ]
+        },
+        {
+          "title": "Bewaren en drinken",
+          "paragraphs": [
+            "Organiseer bakjes met deksels bij elkaar en zet geschikte opwarmbakken vooraan. Label restjes met datum zodat veilig bewaren niet verloren gaat in een ondoorzichtige stapel.",
+            "Maak drinkflessen en doppen volledig schoon en laat ze drogen. Vul ze met koud water en laat ze niet langdurig heet in een auto liggen. Gebruik een materiaal dat bij jouw leven past; consequent schoonmaken is belangrijker dan het meest exclusieve materiaal."
+          ]
+        },
+        {
+          "title": "De vervanglijst zonder haast",
+          "paragraphs": [
+            "Zet ieder item in één van vier vakken: goed gebruiken, alleen koud gebruiken, binnen drie maanden vervangen of direct stoppen wegens duidelijke schade. Noteer bij vervanging de functie en maat; anders koop je vanuit onrust iets dat niet past.",
+            "Begin met spullen die dagelijks direct contact hebben met heet eten. Zeldzame accessoires komen later of helemaal niet."
+          ],
+          "note": "Een lege koopmand met een sterke routine is een betere reset dan een volle koopmand zonder nieuw gedrag."
+        }
+      ],
+      "assignment": {
+        "title": "De reset van één lade en één routine",
+        "time": "25 minuten",
+        "intro": "Beperk de scope zodat je vandaag echt afrondt.",
+        "steps": [
+          "Kies de lade of plank met je meest gebruikte voedselcontactmaterialen.",
+          "Sorteer op geschikt, anders gebruiken, later vervangen en duidelijk versleten.",
+          "Richt een zichtbare opwarmplek en een vaste restjesplek in.",
+          "Test vanavond je nieuwe routine en noteer één frictiepunt."
+        ],
+        "reflection": "Welke inrichting maakt de goede keuze bijna automatisch?"
+      },
+      "remember": [
+        "Richt de keuken in rond gedrag, niet rond een perfect plaatje.",
+        "Dagelijks heet voedselcontact krijgt de hoogste vervangprioriteit.",
+        "Veilig bewaren, schoonmaken en ventileren blijven onderdeel van de reset."
+      ]
     },
     {
-      "id": "les-48-house-dust-invisible-toxin-carrier",
-      "index": 48,
-      "title": "Les 48: Huisstof: de onzichtbare drager van toxines",
-      "type": "Theorie",
+      "id": "cr2-les-14-huisstof-lucht",
+      "index": 14,
+      "title": "Huisstof, lucht & ventilatie",
+      "type": "Thuis",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "Binnenlucht is geen detail: koken, douchen, schoonmaken, kaarsen, sprays en slijtage komen samen in de ruimte waar je veel uren doorbrengt.",
+      "opening": [
+        "Huisstof is een mengsel van vezels, huidcellen, aarde van buiten, verbrandingsdeeltjes en materiaalresten. Sommige chemische stoffen hechten zich eraan. Vooral jonge kinderen krijgen relatief makkelijk stof binnen via handen en vloercontact.",
+        "De oplossing is niet steriel wonen. Het is bronbeperking, ventilatie en een schoonmaakritme dat stof verwijdert in plaats van verplaatst."
+      ],
+      "sections": [
+        {
+          "title": "Ventileer op het moment dat de bron actief is",
+          "paragraphs": [
+            "Ventilatie werkt het best wanneer vervuiling ontstaat. Zet afzuiging aan bij koken en laat die nog even doorlopen. Ventileer tijdens en na douchen om vocht en schimmelgroei te beperken. Lucht na schoonmaken, klussen of het uitpakken van sterk ruikende nieuwe spullen.",
+            "Een raam de hele dag op een kier is niet in iedere woning de beste of energiezuinigste oplossing. Gebruik aanwezige ventilatieroosters en mechanische ventilatie volgens woningadvies en blokkeer roosters niet."
+          ],
+          "bullets": [
+            "Zet de afzuigkap aan vóór de eerste pan heet wordt.",
+            "Gebruik deksels om kookdamp en energieverlies te beperken.",
+            "Rook niet binnen en beperk wierook, geurkaarsen en aerosols.",
+            "Pak vocht- of schimmelproblemen bij de bron aan; alleen geur maskeren helpt niet."
+          ]
+        },
+        {
+          "title": "Verwijder stof zonder het op te jagen",
+          "paragraphs": [
+            "Neem gladde oppervlakken vochtig af en stofzuig langzaam, vooral langs randen en op plekken waar kinderen spelen. Een stofzuiger met goed passend filter en tijdig onderhoud voorkomt dat een deel van fijn stof weer wordt uitgeblazen.",
+            "Was handen vóór eten, zeker na schoonmaken, klussen of vloercontact. Dat is een eenvoudige manier om de route van stof naar mond te onderbreken."
+          ],
+          "note": "Meer geur is geen bewijs van meer schoon. Een neutraal ruikend huis kan juist betekenen dat je minder parfums en sprays toevoegt."
+        },
+        {
+          "title": "Meet alleen als de uitkomst tot actie leidt",
+          "paragraphs": [
+            "CO₂-meters kunnen helpen om ventilatiepatronen te begrijpen, maar meten niet alle verontreiniging. Luchtreinigers kunnen specifieke deeltjes verminderen, maar lossen vocht, bronemissies of slecht ventilatiegedrag niet op.",
+            "Koop meet- of filterapparatuur pas als je weet welke vraag je beantwoordt, welke prestatie nodig is en hoe je onderhoud organiseert."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "De luchtwandeling",
+        "time": "15 minuten",
+        "intro": "Loop door je huis en noteer bronnen, routes en eenvoudige ingrepen.",
+        "steps": [
+          "Controleer keukenafzuiging, badkamer, roosters en slaapkamer.",
+          "Zoek drie stofverzamelplekken die vaak worden vergeten.",
+          "Kies één bron die je vermindert en één ventilatiemoment dat je vastzet.",
+          "Plan twee korte stofrondes per week in plaats van één grote uitputtingsslag."
+        ],
+        "reflection": "Welke bron probeerde je eerder vooral met geur of schoonmaakmiddel te maskeren?"
+      },
+      "remember": [
+        "Ventileer wanneer koken, douchen of klussen de bron activeert.",
+        "Vochtig afnemen en rustig stofzuigen verwijdert stof beter dan droog verplaatsen.",
+        "Apparatuur vult bronaanpak en ventilatie aan, maar vervangt die niet."
+      ]
+    },
+    {
+      "id": "cr2-les-15-pannen-textiel-coatings",
+      "index": 15,
+      "title": "Pannen, textiel & coatings",
+      "type": "Thuis",
+      "duration_min": 10,
+      "draft": false,
+      "lead": "Coatings hebben een functie. De kunst is herkennen wanneer je die functie nodig hebt, hoe je veilig gebruikt en wanneer schade een grens bereikt.",
+      "opening": [
+        "Anti-aanbakpannen, waterafstotende jassen en vlekwerend textiel maken het leven makkelijker. Sommige toepassingen hebben PFAS gebruikt of gebruiken andere coatings. Een productcategorie vertelt niet altijd welke chemie in jouw specifieke artikel zit.",
+        "Daarom beoordeel je functie, informatie, staat en gebruik. Je vervangt niet blind; je stopt ook niet met nadenken omdat een product ooit was toegestaan."
+      ],
+      "sections": [
+        {
+          "title": "Pannen: temperatuur en schade eerst",
+          "paragraphs": [
+            "Verhit een lege anti-aanbakpan niet langdurig op hoog vuur. Gebruik passend keukengerei en volg de instructies voor reinigen en maximale temperatuur. Een pan met duidelijk afbladderende of sterk beschadigde coating is aan vervanging toe.",
+            "Roestvrij staal, gietijzer en plaatstaal zijn alternatieven met een eigen leercurve. Kies wat past bij je kookstijl; een pan die je beheerst en goed onderhoudt is waardevoller dan een ‘perfect’ materiaal dat ongebruikt blijft."
+          ],
+          "bullets": [
+            "Kook op de laagste temperatuur die het gerecht goed bereidt.",
+            "Gebruik ventilatie, zeker bij bakken en braden.",
+            "Stap over op hout, siliconen volgens instructie of ander geschikt zacht gereedschap.",
+            "Vervang op basis van duidelijke schade en gebruik, niet alleen leeftijd."
+          ]
+        },
+        {
+          "title": "Textiel: koop de functie bewust",
+          "paragraphs": [
+            "Waterdichtheid is zinvol voor een regenjas, maar vlekwerendheid is niet automatisch nodig voor ieder tafelkleed, tapijt of bankstel. Vraag bij nieuwe aankopen naar PFAS-vrije water- of vuilafstoting en bewaar productinformatie.",
+            "Was nieuwe kleding volgens het label vóór langdurig huidcontact wanneer dat praktisch is. Was daarna alleen wanneer nodig, op passende temperatuur en zonder onnodig veel middel; dat beperkt slijtage en verlengt de levensduur."
+          ],
+          "note": "De beste coating is soms geen coating: kies een wasbare hoes, donkere kleur of materiaal dat van zichzelf bij de functie past."
+        },
+        {
+          "title": "Laat claims bewijs dragen",
+          "paragraphs": [
+            "Termen als eco, green, clean of PFOA-free kunnen smaller zijn dan ze klinken. Zoek naar een verklaring over de hele relevante stofgroep, een erkend keurmerk met openbare criteria of concrete materiaalinformatie.",
+            "Als een fabrikant geen antwoord geeft, is dat informatie. Je hoeft niet te bewijzen dat het product schadelijk is om voor een transparanter alternatief te kiezen."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Maak je coatingregister",
+        "time": "15 minuten",
+        "intro": "Kies twee pannen en drie water- of vuilafstotende spullen.",
+        "steps": [
+          "Noteer functie, gebruiksfrequentie, zichtbare staat en beschikbare productinformatie.",
+          "Controleer of de afstotende functie echt nodig is.",
+          "Kies één beter gebruiksritueel en maximaal één vervanging voor later.",
+          "Bewaar de criteria waaraan een toekomstig alternatief moet voldoen."
+        ],
+        "reflection": "Waar kun je de gewenste functie bereiken zonder extra coating?"
+      },
+      "remember": [
+        "Beoordeel coatings op functie, staat, temperatuur en transparantie.",
+        "PFOA-vrij betekent niet automatisch vrij van alle PFAS.",
+        "Een onnodige afstotende functie kun je bij een volgende aankoop eenvoudig weglaten."
+      ]
+    },
+    {
+      "id": "cr2-les-16-schoonmaken",
+      "index": 16,
+      "title": "Schoonmaken zonder overdaad",
+      "type": "Thuis",
       "duration_min": 8,
       "draft": false,
-      "content_html": "<h2>🌱 Les 48</h2>\n<h3>Huisstof: de onzichtbare drager van toxines</h3>\n\n<p>Ik dacht altijd dat stof gewoon irritant was – iets wat je elke week moest wegvegen omdat het er slordig uitzag. Tot ik ontdekte wat er écht in zat. Huisstof is namelijk niet alleen huidschilfers en pluis. Het is een cocktail van microplastics, chemicaliën en gifstoffen die je elke dag opnieuw inademt.</p>\n\n<h4>Wat zit er in huisstof?</h4>\n\n<ul>\n<li><strong>Microplastics</strong> → afkomstig van kleding, meubels, vloerbedekking en elektronica.</li>\n<li><strong>Weekmakers & vlamvertragers</strong> → uit meubels, matrassen en elektronica.</li>\n<li><strong>Pesticiden</strong> → resten die via schoenen en ramen je huis binnenkomen.</li>\n<li><strong>Schimmels & bacteriën</strong> → vooral in vochtige ruimtes zoals de badkamer.</li>\n</ul>\n\n<p>Het bizarre is: kinderen krijgen vaak nóg meer binnen, omdat ze dichter bij de grond spelen en meer contact hebben met hun handen en mond.</p>\n\n<h4>Waarom is dit een probleem?</h4>\n\n<ul>\n<li>Je ademt stofdeeltjes in → toxines komen direct in je longen.</li>\n<li>Je slikt het in via je handen, eten en drinken.</li>\n<li>Het levert een constante lage dosis gifstoffen op – elke dag weer.</li>\n</ul>\n\n<h4>Wat je eraan kunt doen</h4>\n\n<ul>\n<li><strong>Regelmatig stofzuigen</strong> – bij voorkeur met een HEPA-filter, zodat de kleinste deeltjes echt verdwijnen.</li>\n<li><strong>Dweilen en nat afnemen</strong> in plaats van alleen droog stoffen (anders dwarrelt het weer rond).</li>\n<li><strong>Ventileren</strong> – frisse lucht vermindert ophoping.</li>\n<li><strong>Schoenen uit binnen</strong> – voorkomt dat pesticiden en chemicaliën via je schoenen het huis in komen.</li>\n<li><strong>Was textiel regelmatig</strong> (gordijnen, kussens, dekens), want dit zijn echte stofverzamelaars.</li>\n</ul>\n\n<p>Wat ik zelf ervoer: toen ik begon met schoenen uitdoen in huis en vaker nat schoonmaken, werd mijn luchtkwaliteit merkbaar beter. Minder \"zware\" lucht, meer frisheid.</p>\n\n<p><strong>👉 Jouw actie:</strong> kies deze week één gewoonte om huisstof te verminderen. Zet bijvoorbeeld een vaste dag in je agenda om te dweilen of begin met schoenen bij de voordeur uit.</p>\n\n<p>In de volgende les kijken we naar een andere verborgen bron: schoonmaak- en verzorgingsproducten in je huis – en hoe je ze eenvoudig kunt vervangen zonder in te leveren op hygiëne of gemak.</p>"
+      "lead": "Schoon hoeft niet scherp te ruiken. Met weinig, gericht gebruikte middelen bescherm je binnenlucht, huid en materiaal.",
+      "opening": [
+        "Schoonmaakmiddelen hebben een nuttige functie, maar meer product, meer schuim of meer parfum betekent niet automatisch meer hygiëne. Verkeerd mengen kan zelfs gevaarlijke gassen veroorzaken.",
+        "Je doel is het juiste middel voor de juiste vervuiling, in de juiste hoeveelheid, met ventilatie en veilige opslag."
+      ],
+      "sections": [
+        {
+          "title": "Begin mechanisch",
+          "paragraphs": [
+            "Water, een geschikte doek, tijd en wrijving verwijderen veel gewone vervuiling. Gebruik pas extra middel wanneer vet, kalk of hygiënerisico dat vraagt. Volg de dosering; overdoseren laat resten achter en belast lucht en water onnodig.",
+            "Spray bij voorkeur op de doek in plaats van ruim door de kamer, tenzij het etiket anders voorschrijft. Zo beperk je nevel die je kunt inademen."
+          ],
+          "bullets": [
+            "Ventileer tijdens intensief schoonmaken.",
+            "Gebruik handschoenen wanneer het etiket dat vraagt of je huid gevoelig reageert.",
+            "Bewaar middelen in de originele verpakking, buiten bereik van kinderen.",
+            "Meng nooit bleek met azijn, zuur, ammoniak of andere reinigers."
+          ]
+        },
+        {
+          "title": "Desinfecteren is niet de dagelijkse standaard",
+          "paragraphs": [
+            "Voor gewone huishoudelijke oppervlakken is reinigen meestal voldoende. Desinfectie is zinvol in specifieke situaties, bijvoorbeeld volgens zorgadvies of bij een bijzonder besmettingsrisico. Onnodig breed gebruik voegt blootstelling toe zonder duidelijk voordeel.",
+            "Keukenhygiëne draait vooral om handen, rauw en bereid voedsel scheiden, passende temperaturen en tijdig schoonmaken. Een sterk ruikende spray kan dat gedrag niet vervangen."
+          ],
+          "note": "Geur is een prikkel, geen meetinstrument voor schoon of veilig."
+        },
+        {
+          "title": "Ook ‘natuurlijk’ kan irriteren",
+          "paragraphs": [
+            "Etherische oliën en zelfgemaakte mengsels zijn niet automatisch mild. Geconcentreerde stoffen kunnen huid, luchtwegen en huisdieren belasten. Bovendien kunnen zelfmaakproducten onvoorspelbaar reageren of verkeerd worden bewaard.",
+            "Kies eenvoudige, goed gelabelde producten en beperk variatie. Eén allesreiniger, een passend kalkmiddel en een afwasmiddel zijn voor veel huishoudens een werkbare basis."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Halveer je schoonmaakkast",
+        "time": "20 minuten",
+        "intro": "Haal niets gevaarlijks over in een andere verpakking en gooi chemisch afval alleen via de juiste route weg.",
+        "steps": [
+          "Groepeer producten op functie en zoek doublures.",
+          "Controleer etiketten, sluitingen en houdbaarheid.",
+          "Kies een kernset en zet specialistische middelen apart.",
+          "Maak een doseer- en ventilatieregel voor je vaste schoonmaakmoment."
+        ],
+        "reflection": "Welk product gebruikte je vooral voor geur of gewoonte, niet voor een duidelijke functie?"
+      },
+      "remember": [
+        "Gebruik het juiste middel, zo weinig als nodig en volgens het etiket.",
+        "Meng schoonmaakmiddelen nooit op eigen inzicht.",
+        "Dagelijks desinfecteren is in een normaal huishouden meestal niet nodig."
+      ]
     },
     {
-      "id": "les-49-clean-alternatives-household-products",
-      "index": 49,
-      "title": "Les 49: Schone alternatieven voor huishoudproducten",
-      "type": "Praktijk",
+      "id": "cr2-les-17-verzorging",
+      "index": 17,
+      "title": "Verzorging & etiketten",
+      "type": "Thuis",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "Je badkamer wordt overzichtelijker wanneer je begint bij functie, huidreactie en gebruiksoppervlak — niet bij een eindeloze zwarte lijst.",
+      "opening": [
+        "Cosmetica in de EU moeten aan regels voldoen en ingrediënten vermelden. Dat betekent niet dat ieder product voor iedere persoon prettig is. Irritatie, allergie, inhalatie van sprays en de hoeveelheid producten die je gebruikt blijven praktisch relevant.",
+        "De snelste winst is vaak minder stapelen: minder verschillende geuren, serums, sprays en producten met bijna dezelfde functie."
+      ],
+      "sections": [
+        {
+          "title": "Lees een INCI-lijst zonder scheikundediploma",
+          "paragraphs": [
+            "Ingrediënten staan grofweg in aflopende volgorde tot lage concentraties, waarna de volgorde flexibeler kan zijn. De lijst vertelt wat erin zit, niet automatisch hoeveel risico het product in jouw gebruik oplevert.",
+            "Begin daarom met vier vragen: wat is de functie, blijft het op de huid of spoel je het af, hoe groot is het oppervlak en hoe vaak gebruik je het? Een dagelijkse bodylotion telt anders dan een maandelijkse haarbehandeling."
+          ],
+          "bullets": [
+            "Kies parfumvrij als geur je huid of luchtwegen prikkelt; ‘ongeparfumeerd ruikend’ is niet altijd hetzelfde.",
+            "Vermijd het inademen van poeder- en spuitnevel waar een crème of roller dezelfde functie heeft.",
+            "Gebruik zonbescherming volgens deskundig advies; angst voor ingrediënten mag huidbescherming niet ondermijnen.",
+            "Stop bij aanhoudende irritatie en bespreek klachten met huisarts of dermatoloog."
+          ]
+        },
+        {
+          "title": "Marketingwoorden zijn geen totaalbeoordeling",
+          "paragraphs": [
+            "Dermatologisch getest, clean beauty, natuurlijk en vrij van klinken geruststellend, maar zeggen zonder methode en criteria weinig over het hele product. Een ‘vrij van’-claim kan één bekend ingrediënt weglaten en een alternatief gebruiken.",
+            "Kijk naar transparantie, functie en jouw ervaring. Een eenvoudig product dat je huid goed verdraagt en correct gebruikt, is vaak een betere keuze dan een dure routine vol actieve stoffen."
+          ],
+          "note": "Je huidbarrière ondersteunen kan betekenen dat je juist minder wisselt en minder vaak experimenteert."
+        },
+        {
+          "title": "Bijzondere levensfasen vragen gerichte vragen",
+          "paragraphs": [
+            "Bij zwangerschap, borstvoeding, jonge kinderen, eczeem of medische huidbehandeling is een algemene internetlijst onvoldoende. Vraag verloskundige, arts of apotheker naar een specifiek ingrediënt en product, inclusief concentratie en gebruik.",
+            "Neem de verpakking of ingrediëntenlijst mee. Een concrete vraag levert beter advies op dan ‘is cosmetica giftig?’."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "De vijf-productenroutine",
+        "time": "15 minuten",
+        "intro": "Kies de vijf producten die samen het grootste deel van je huid- en haarverzorging vormen.",
+        "steps": [
+          "Noteer functie, frequentie, leave-on of rinse-off en eventuele reactie.",
+          "Zoek doublures of een spray die door een andere vorm vervangen kan worden.",
+          "Kies één product dat je opmaakt maar niet opnieuw koopt.",
+          "Bewaar één concrete vraag voor een professional als jouw situatie dat vraagt."
+        ],
+        "reflection": "Welk product voegt echte functie toe, en welk product vooral belofte of geur?"
+      },
+      "remember": [
+        "Gebruikssituatie is belangrijker dan één los ingrediënt op een zwarte lijst.",
+        "Minder producten betekent minder blootstelling én minder kans op irritatie.",
+        "Bij medische of bijzondere situaties stel je een concrete vraag aan een professional."
+      ]
+    },
+    {
+      "id": "cr2-les-18-lichaam",
+      "index": 18,
+      "title": "Wat je lichaam zelf doet",
+      "type": "Lichaam",
+      "duration_min": 10,
+      "draft": false,
+      "lead": "Je lichaam heeft geen ‘detoxknop’, maar een netwerk van organen dat stoffen verwerkt, uitscheidt, opslaat of soms maar langzaam kwijt raakt.",
+      "opening": [
+        "Het woord detox doet alsof alle ongewenste stoffen één soort afval zijn. In werkelijkheid gedragen stoffen zich verschillend. Wateroplosbare afbraakproducten kunnen via urine verdwijnen, andere via gal en ontlasting, vluchtige stoffen via uitademing. Sommige persistente stoffen blijven lang aanwezig.",
+        "Dat maakt de rol van lever en nieren belangrijk, maar niet magisch. Meer ‘stimuleren’ is niet automatisch beter en een pijnlijke of extreme reactie is geen bewijs dat ontgifting werkt."
+      ],
+      "sections": [
+        {
+          "title": "Lever, nieren, darmen en longen als team",
+          "paragraphs": [
+            "De lever zet veel lichaamseigen en lichaamsvreemde stoffen om. De nieren filteren bloed en regelen onder andere vocht en zouten. De darmen nemen stoffen op en voeren onverteerbare resten en galproducten af. De longen wisselen gassen uit en kunnen ingeademde deeltjes deels opvangen en afvoeren.",
+            "Geen enkel orgaan werkt los. Voldoende eten, drinken, slaap en beweging ondersteunen algemene gezondheid, maar versnellen niet automatisch de uitscheiding van iedere specifieke stof."
+          ],
+          "bullets": [
+            "Urine zegt vooral iets over wat op dat moment wordt uitgescheiden, niet over je totale ‘toxinelast’.",
+            "Zweten regelt vooral temperatuur; het is geen universele hoofdroute voor chemische ontgifting.",
+            "Regelmatige ontlasting hoort bij gezondheid, maar agressieve laxeermiddelen zijn geen detox.",
+            "Je lever ‘reinigen’ met supplementen is niet nodig en kan schade geven."
+          ]
+        },
+        {
+          "title": "Waarom je je niet per se anders voelt",
+          "paragraphs": [
+            "Minder blootstelling kan verstandig zijn zonder dat je morgen meer energie voelt. Vermoeidheid, hoofdpijn, huidklachten en concentratieproblemen hebben veel mogelijke oorzaken. Ze zijn niet specifiek genoeg om ‘toxische belasting’ als diagnose te gebruiken.",
+            "Dat is geen teleurstelling; het is een beschermende waarheid. Je hoeft geen lichamelijke sensatie te produceren om te bewijzen dat je goede preventieve keuzes maakt."
+          ],
+          "note": "Een gezonde gewoonte mag waardevol zijn omdat ze blootstelling plausibel verlaagt, ook zonder dramatische voor-en-na-ervaring."
+        },
+        {
+          "title": "Wanneer klachten medische aandacht vragen",
+          "paragraphs": [
+            "Nieuwe, ernstige of aanhoudende klachten horen bij een arts, niet bij een detoxprotocol. Neem ook contact op bij geelzucht, donkere urine, hevige buikpijn, ademhalingsproblemen, bewustzijnsverandering of vermoeden van acute vergiftiging.",
+            "Vertel concreet welke stof, hoeveelheid, route en tijd mogelijk betrokken waren. Neem een verpakking of foto van het etiket mee als dat veilig kan."
+          ],
+          "warning": "Stel medische beoordeling niet uit omdat klachten volgens een influencer een normale ‘detoxreactie’ zouden zijn."
+        }
+      ],
+      "assignment": {
+        "title": "Vervang je detoxverhaal",
+        "time": "10 minuten",
+        "intro": "Schrijf drie zinnen die je vanaf nu gebruikt als iemand een wonderdetox claimt.",
+        "steps": [
+          "Noem welk orgaan of proces werkelijk betrokken zou moeten zijn.",
+          "Vraag om de specifieke stof en aangetoonde uitscheidingsroute.",
+          "Vraag welk bewijs er is voor voordeel én veiligheid.",
+          "Formuleer je eigen nuchtere definitie van Clean Reset."
+        ],
+        "reflection": "Geeft een preciezer lichaamsbeeld je minder magie, of juist meer vertrouwen?"
+      },
+      "remember": [
+        "Stoffen worden via verschillende routes verwerkt en uitgescheiden.",
+        "Zweten of vaker plassen bewijst geen algemene ontgifting.",
+        "Aanhoudende of ernstige klachten vragen medische beoordeling."
+      ]
+    },
+    {
+      "id": "cr2-les-19-voeding",
+      "index": 19,
+      "title": "Voeden voor herstel en balans",
+      "type": "Lichaam",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "Geen detoxmenu, maar een voedingsbasis die energie, darmen en normale orgaanfuncties ondersteunt zonder verbodenlijst.",
+      "opening": [
+        "Je lichaam heeft eiwitten, koolhydraten, vetten, vitaminen, mineralen en vocht nodig voor talloze processen. Een sapkuur levert vaak weinig eiwit, vezels en energie en kan duizeligheid, honger of verlies van spiermassa geven. Dat is geen teken dat ‘gifstoffen loskomen’.",
+        "We bouwen daarom met gewone voeding: gevarieerd, voldoende en passend bij jouw medische situatie, cultuur en budget."
+      ],
+      "sections": [
+        {
+          "title": "Gebruik de bordbasis",
+          "paragraphs": [
+            "Vul een groot deel van je maaltijd met groente, voeg een bron van eiwit toe, kies een volkoren of andere passende koolhydraatbron en gebruik vetten in een normale hoeveelheid. Fruit, noten en peulvruchten helpen variatie en vezels verhogen.",
+            "Vezels ondersteunen de darmfunctie, maar bouw ze geleidelijk op en drink passend. Bij darmziekte, nierziekte of een medisch dieet kan standaardadvies ongeschikt zijn; volg dan je behandelaar."
+          ],
+          "bullets": [
+            "Varieer in kleur, soort en bereidingswijze.",
+            "Eet voldoende eiwit verdeeld over de dag.",
+            "Kies regelmatig volkorenproducten en peulvruchten als die bij je passen.",
+            "Drink naar dorst en omstandigheden; extreme hoeveelheden water zijn niet gezonder."
+          ]
+        },
+        {
+          "title": "Stop met losse voedingsmiddelen verheffen",
+          "paragraphs": [
+            "Broccoli, knoflook, bessen en kruiden kunnen prima onderdelen van een gezond patroon zijn. Maar geen enkel voedingsmiddel trekt PFAS of microplastics gericht uit je lichaam. Laboratoriumonderzoek naar een stofje in een plant is niet hetzelfde als een bewezen klinisch detoxeffect.",
+            "Gebruik ‘detoxvoeding’ dus als receptinspiratie, niet als behandeling. Variatie beschermt je bovendien tegen de nadelen van extreem veel van één product."
+          ],
+          "note": "Een voedzame maaltijd hoeft niet te bewijzen dat hij ontgift; voeden is al een waardevolle functie."
+        },
+        {
+          "title": "Maak regelmaat makkelijk",
+          "paragraphs": [
+            "Een basisvoorraad verkleint de kans dat je op drukke momenten terugvalt op dure kuren of weinig voedzame oplossingen. Denk aan diepvriesgroente, havermout, peulvruchten, eieren of een passende andere eiwitbron, volkorenproducten, noten en fruit.",
+            "Kies drie maaltijden die je zonder veel denken kunt maken. Herhaling is geen mislukking; het is infrastructuur."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Ontwerp drie ankermaaltijden",
+        "time": "20 minuten",
+        "intro": "Maak één ontbijt, lunch en avondmaaltijd die voedzaam, betaalbaar en realistisch zijn.",
+        "steps": [
+          "Voeg aan iedere maaltijd een eiwitbron en plantaardig onderdeel toe.",
+          "Kies ingrediënten die je in meerdere gerechten gebruikt.",
+          "Plan één snelle noodvariant uit vriezer of voorraadkast.",
+          "Schrap ieder ingrediënt dat er alleen in zit vanwege een onbewezen detoxclaim."
+        ],
+        "reflection": "Welke maaltijd ondersteunt je het meest omdat je hem werkelijk blijft maken?"
+      },
+      "remember": [
+        "Een volwaardig patroon ondersteunt gezondheid beter dan een sapkuur.",
+        "Geen enkel voedingsmiddel verwijdert gericht PFAS of microplastics.",
+        "Voldoende, gevarieerd en haalbaar is de kern."
+      ]
+    },
+    {
+      "id": "cr2-les-20-slaap-beweging",
+      "index": 20,
+      "title": "Slaap, beweging & zweten",
+      "type": "Lichaam",
       "duration_min": 8,
       "draft": false,
-      "content_html": "<h2>🌱 Les 49</h2>\n<h3>Schone alternatieven voor huishoudproducten</h3>\n\n<p>Toen ik mijn keukenkastje met schoonmaakmiddelen eens goed bekeek, stond ik versteld. Flessen vol chemicaliën, \"extra krachtig\", \"tegen alle bacteriën\" – maar al die geurtjes en schuimlagen bleken vooral mijn luchtwegen en huid te belasten. Het was alsof ik mijn huis probeerde schoon te maken door mezelf langzaam vuiler te maken.</p>\n\n<p>Het goede nieuws: je hebt maar een paar basisproducten nodig om je huis fris en hygiënisch te houden – zonder dat je toxines toevoegt.</p>\n\n<h4>De basics voor een schoon huis zonder gif</h4>\n\n<ul>\n<li><strong>Azijn</strong> → krachtig tegen kalk en vet. Perfect voor badkamer en keuken.</li>\n<li><strong>Baking soda</strong> → werkt als schuurmiddel, geurvreter én mild reinigingsmiddel.</li>\n<li><strong>Groene zeep</strong> → ideaal voor vloeren en algemene schoonmaak.</li>\n<li><strong>Citroen</strong> → antibacterieel en heerlijk fris geurend.</li>\n<li><strong>Etherische oliën (optioneel)</strong> → lavendel of tea tree voor extra desinfectie en geur.</li>\n</ul>\n\n<h4>Voorbeelden uit de praktijk</h4>\n\n<ul>\n<li><strong>Glasreiniger?</strong> → water + azijn in een spuitfles.</li>\n<li><strong>Allesreiniger?</strong> → water + groene zeep.</li>\n<li><strong>Schuurmiddel?</strong> → baking soda met een beetje water.</li>\n<li><strong>Luchtverfrisser?</strong> → laat die weg en zet een raam open, of gebruik een diffuser met etherische olie.</li>\n</ul>\n\n<h4>Waarom dit beter werkt</h4>\n\n<ul>\n<li>Je vermijdt vluchtige organische stoffen (VOS) die in veel commerciële producten zitten.</li>\n<li>Geen verborgen parabenen, weekmakers of parfumstoffen die je huid en lucht belasten.</li>\n<li>Goedkoper en milieuvriendelijker.</li>\n</ul>\n\n<p>Wat ik zelf merkte: na een paar weken overstappen voelde mijn huis niet alleen frisser, maar ook mijn ademhaling lichter. Geen zware geurtjes meer die in de lucht hingen, maar gewoon écht frisse lucht.</p>\n\n<p><strong>👉 Jouw actie:</strong> vervang deze week één schoonmaakproduct door een DIY-alternatief of een natuurlijk merk. Begin bijvoorbeeld met glasreiniger of allesreiniger. Zo merk je direct dat \"schoon\" ook écht schoon kan voelen.</p>\n\n<p>In de volgende (en laatste) les van dit hoofdstuk brengen we alles samen: hoe je je hele leefomgeving detox-proof maakt met een paar simpele leefregels die je blijvend kunt volhouden.</p>"
+      "lead": "Slaap en beweging zijn krachtige gezondheidsgewoonten. Ze hoeven niet als ‘detoxhack’ vermomd te worden om belangrijk te zijn.",
+      "opening": [
+        "Regelmatig bewegen ondersteunt hart, spieren, stofwisseling, stemming en slaap. Slaap ondersteunt herstel, geheugen en immuunfunctie. Dat zijn grote voordelen — maar niet hetzelfde als bewezen versnelde verwijdering van iedere chemische stof.",
+        "Zweten is vooral temperatuurregeling. Sauna of sport kan prettig zijn voor geschikte mensen, maar zweetvolume is geen score voor hoeveel ‘toxines’ je kwijt bent."
+      ],
+      "sections": [
+        {
+          "title": "Bouw beweging rond je echte week",
+          "paragraphs": [
+            "Combineer dagelijkse lichte beweging met momenten die conditie en spierkracht uitdagen, passend bij je gezondheid en niveau. Een wandeling na het eten, fietsen naar werk of twee korte krachtsessies kan duurzamer zijn dan één extreem weekendprotocol.",
+            "Werk je in vervuilde lucht of stof, dan is de locatie van beweging relevant. Kies waar mogelijk een route verder van druk verkeer en volg luchtkwaliteits- of hitteadviezen wanneer die gelden."
+          ],
+          "bullets": [
+            "Koppel tien minuten wandelen aan een bestaande maaltijd.",
+            "Plan spierversterkende beweging op vaste dagen.",
+            "Bouw intensiteit geleidelijk op en respecteer herstel.",
+            "Douche en trek schone kleding aan na werk of sport met veel stofcontact."
+          ]
+        },
+        {
+          "title": "Maak slaap minder onderhandelbaar",
+          "paragraphs": [
+            "Een vaste opstaantijd, voldoende tijd in bed, ochtendlicht en een rustige afbouw helpen je ritme. Alcohol kan slaperig maken maar slaapkwaliteit verstoren. Laat cafeïne op de dag aansluiten bij jouw gevoeligheid.",
+            "Lig je langdurig wakker, snurk je luid met ademstops of ben je overdag extreem slaperig, bespreek dat met een arts. Een supplement of detoxkuur behandelt een slaapstoornis niet."
+          ],
+          "note": "Herstelgewoonten zijn geen straf voor blootstelling; ze zijn een basis waarop je iedere dag kunt bouwen."
+        },
+        {
+          "title": "Sauna is optioneel, niet verplicht",
+          "paragraphs": [
+            "Als je sauna prettig vindt en medisch veilig kunt gebruiken, zie het dan als ontspanning en warmtebelasting, niet als reinigingsbehandeling. Drink normaal, voorkom alcohol en verlaat de sauna bij duizeligheid, misselijkheid of onwel voelen.",
+            "Bij zwangerschap, hart- en vaatproblemen, medicatie of andere aandoeningen vraag je vooraf individueel advies. Meer hitte is niet automatisch meer gezondheid."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Kies twee herstelankers",
+        "time": "10 minuten",
+        "intro": "Maak één beweeganker en één slaapanker die je zeven dagen kunt uitvoeren.",
+        "steps": [
+          "Koppel beweging aan een bestaand moment.",
+          "Kies een vaste laatste handeling vóór bed.",
+          "Maak beide acties klein genoeg voor je drukste dag.",
+          "Meet uitvoering, niet zweet, calorieën of een vaag detoxgevoel."
+        ],
+        "reflection": "Welke gewoonte ondersteunt je gezondheid ook als hij niets spectaculairs ‘afvoert’?"
+      },
+      "remember": [
+        "Beweging en slaap zijn waardevol zonder detoxclaim.",
+        "Zweten is vooral temperatuurregeling.",
+        "Extreme hitte of training is geen bewijs van betere ontgifting."
+      ]
     },
     {
-      "id": "les-50-detox-proof-living-environment",
-      "index": 50,
-      "title": "Les 50: Je leefomgeving detox-proof maken",
-      "type": "Praktijk",
-      "duration_min": 8,
+      "id": "cr2-les-21-supplementen",
+      "index": 21,
+      "title": "Supplementen: wel of niet?",
+      "type": "Lichaam",
+      "duration_min": 10,
       "draft": false,
-      "content_html": "<h2>🌱 Les 50</h2>\n<h3>Je leefomgeving detox-proof maken</h3>\n\n<p>Toen ik al deze stappen had doorlopen – voeding, cosmetica, beweging, slaap en uiteindelijk mijn huis – viel er iets bijzonders op. Het voelde alsof mijn hele omgeving lichter werd. Niet omdat ik alles perfect had gedaan, maar omdat ik mijn basisregels had veranderd. En dat gaf me rust.</p>\n\n<h4>De 5 leefregels voor een detox-proof omgeving</h4>\n\n<ol>\n<li><strong>Frisse lucht eerst</strong><br>\nVentileer dagelijks. Zet ramen open, gebruik planten of een luchtreiniger. Schone lucht = minder toxines in je longen.</li>\n\n<li><strong>Schoonmaken zonder gif</strong><br>\nGebruik simpele middelen als azijn, baking soda en groene zeep. Je huis blijft net zo schoon, maar je belast je lichaam niet.</li>\n\n<li><strong>Minimaliseer plastic</strong><br>\nBewaar eten in glas of RVS. Vermijd wegwerpplastic en verwarm nooit voedsel in plastic.</li>\n\n<li><strong>Check je labels</strong><br>\nOf het nu cosmetica, schoonmaak of voeding is – lees altijd de ingrediënten. Weet wat je binnenkrijgt.</li>\n\n<li><strong>Houd stof onder controle</strong><br>\nStofzuig en dweil regelmatig, schoenen uit in huis, textiel vaak wassen. Minder stof = minder toxines.</li>\n</ol>\n\n<h4>Het grotere plaatje</h4>\n\n<p>Het gaat niet om een perfect huis of een perfecte levensstijl. Het gaat om het verlagen van de dagelijkse belasting. Elke keuze die jij maakt – of dat nu een waterfilter is, een natuurlijke deo, of een uurtje extra slaap – geeft je lichaam ruimte. Ruimte om op te ruimen, te herstellen en je energie terug te geven.</p>\n\n<p>Toen ik dit zelf inzag, viel er een enorme druk van mijn schouders. Ik hoefde niet meer alles in één keer goed te doen. Ik hoefde alleen maar consequent kleine stappen te blijven zetten.</p>\n\n<p><strong>👉 Jouw laatste opdracht:</strong> kies één leefregel uit dit hoofdstuk die je de komende maand structureel gaat toepassen. Begin klein, maak het haalbaar, en bouw van daaruit verder.</p>\n\n<p><strong>✨ Hiermee heb je het volledige detox-programma afgerond.</strong> Je hebt geleerd wat toxines zijn, hoe ze je lichaam binnendringen, welke schade ze kunnen veroorzaken, en – het allerbelangrijkste – hoe jij de regie pakt om ze te vermijden én af te voeren.</p>\n\n<p>Je bent niet langer passief slachtoffer van je omgeving. Jij bent actief aan het sturen, elke dag opnieuw. En dat is de kracht van dit avontuur.</p>"
+      "lead": "Een supplement kan een vastgesteld tekort of specifieke behoefte behandelen. Dat is iets anders dan een potje dat een onmeetbare ‘detox’ belooft.",
+      "opening": [
+        "Supplementen worden vaak verkocht met woorden als liver support, binder, cleanse of heavy metal detox. De claim klinkt biologisch plausibel, maar zonder onderzoek bij mensen weten we niet of het gewenste effect optreedt, welke dosis werkt en welke schade mogelijk is.",
+        "Ook ‘natuurlijk’ werkzame stoffen kunnen bijwerkingen geven, met medicatie botsen of lever en nieren belasten. De productkwaliteit en werkelijke inhoud kunnen bovendien variëren."
+      ],
+      "sections": [
+        {
+          "title": "De vijf bewijschecks",
+          "paragraphs": [
+            "Vraag eerst welke specifieke stof het supplement zou beïnvloeden. Daarna: is het effect gemeten in mensen, is er een relevante gezondheidsuitkomst, welke dosis en duur zijn onderzocht, welke bijwerkingen traden op en is jouw product vergelijkbaar met het onderzochte product?",
+            "Een verandering in een laboratoriummarker is niet automatisch beter voelen of minder ziekterisico. En een stof die iets bindt in een reageerbuis kan in je darmen ook medicijnen of voedingsstoffen binden."
+          ],
+          "bullets": [
+            "Geen specifieke stof of uitkomst genoemd: claim te vaag.",
+            "Alleen dier- of celonderzoek: nog geen bewezen effect bij mensen.",
+            "‘Herx’, hoofdpijn of diarree als bewijs van werking: alarmsignaal.",
+            "Geheime blend zonder doseringen: niet goed te beoordelen.",
+            "Abonnement of tijdsdruk: commerciële prikkel, geen bewijs."
+          ]
+        },
+        {
+          "title": "Wanneer supplementen wél logisch kunnen zijn",
+          "paragraphs": [
+            "Bij een aangetoond tekort, bepaalde levensfase of medische indicatie kan een gericht supplement zinvol zijn. Denk aan adviezen die voor zwangerschap of specifieke tekorten gelden. Laat keuze en dosering aansluiten op professionele richtlijnen.",
+            "Neem je medicatie, ben je zwanger, geef je borstvoeding of heb je lever- of nierproblemen? Bespreek ieder supplement met arts of apotheker. Neem een foto van etiket, ingrediënten en dosering mee."
+          ],
+          "warning": "Gebruik geen chelatiemiddelen, borax, industriële middelen, hoge doses niacine, langdurig actieve kool of megadoses vitaminen als doe-het-zelfdetox."
+        },
+        {
+          "title": "Een aankoopstop is ook een interventie",
+          "paragraphs": [
+            "Wacht 72 uur bij iedere detoxaankoop. In die tijd zoek je onafhankelijke informatie en beantwoord je de bewijschecks. Vaak zakt de urgentie zodra de marketingprikkel wegvalt.",
+            "Investeer liever in een gewoonte of professionele beoordeling die een concreet probleem oplost. Minder kopen is hier niet passief; het voorkomt risico en bewaart budget."
+          ],
+          "note": "Een goed supplementadvies begint bij een specifieke reden, niet bij een algemeen gevoel dat je ‘vol gifstoffen’ zit."
+        }
+      ],
+      "assignment": {
+        "title": "Audit je supplementenkast",
+        "time": "20 minuten",
+        "intro": "Stop voorgeschreven middelen niet en verander medische doseringen nooit zelfstandig.",
+        "steps": [
+          "Noteer per supplement reden, dosis, startdatum en wie het adviseerde.",
+          "Markeer middelen met een vage detoxclaim of onbekende blend.",
+          "Controleer combinaties met medicatie via arts of apotheker.",
+          "Kies wat je verantwoord voortzet, professioneel laat beoordelen of niet opnieuw koopt."
+        ],
+        "reflection": "Welk potje lost een bewezen behoefte op, en welk potje verkoopt vooral hoop?"
+      },
+      "remember": [
+        "Er is geen bewezen algemeen supplement tegen PFAS of microplastics.",
+        "Natuurlijk betekent niet automatisch veilig of passend.",
+        "Een specifieke indicatie en professionele controle maken supplementgebruik sterker."
+      ]
     },
     {
-      "id": "epilogue-your-detox-journey",
-      "index": 51,
-      "title": "✨ Epiloog – Jouw detoxreis",
-      "type": "Epiloog",
-      "duration_min": 5,
+      "id": "cr2-les-22-resetplan",
+      "index": 22,
+      "title": "Jouw 14-daagse reset",
+      "type": "Plan",
+      "duration_min": 10,
       "draft": false,
-      "content_html": "<h2>✨ Epiloog – Jouw detoxreis</h2>\n\n<p><strong>Lieve jij,</strong></p>\n\n<p>Wat bijzonder dat je dit hele programma hebt doorlopen. Echt even stilstaan bij wat je net hebt gedaan: je hebt jezelf wekenlang verdiept in hoe je je lichaam en je omgeving kunt bevrijden van gifstoffen. Je hebt nieuwe kennis opgedaan, keuzes gemaakt en stappen gezet. En dat verdient respect.</p>\n\n<p>Toen ik deze cursus begon te maken, dacht ik vaak terug aan mijn eigen start. Ik voelde me moe, opgeblazen, soms machteloos. Het idee dat de wereld vol zat met stoffen waar ik geen controle over had, maakte me onzeker. Maar stap voor stap ontdekte ik dat ik wél invloed had. Dat ík de regie kon pakken. En dat heeft mijn leven veranderd.</p>\n\n<p>Datzelfde pad ben jij nu ingeslagen. Misschien voelde het soms als veel, misschien waren er momenten dat je dacht: \"Kan ik dit wel volhouden?\" Maar kijk waar je nu staat. Je hebt de kennis, de tools én de ervaring. Jij weet nu hoe je toxines kunt vermijden, hoe je je lichaam kunt ondersteunen en hoe je een leefomgeving creëert die je energie geeft in plaats van afneemt.</p>\n\n<p>Onthoud dit: detoxen is geen eindpunt. Het is geen eenmalig project dat je afvinkt. Het is een manier van leven. En het mooie is: je hoeft niet perfect te zijn. Elke dag opnieuw kun je kiezen voor kleine stappen – en al die stappen samen maken een wereld van verschil.</p>\n\n<p>Ik hoop dat je met trots terugkijkt op dit avontuur. Dat je voelt dat je sterker bent geworden, meer bewust, meer in verbinding met je lichaam. En dat je dit niet alleen voor jezelf doet, maar ook voor de mensen om je heen. Want een gezonder, energieker jij straalt door naar iedereen in je omgeving.</p>\n\n<p>Blijf nieuwsgierig. Blijf stap voor stap bouwen. En bovenal: wees mild voor jezelf.</p>\n\n<p>Dankjewel dat ik je mocht meenemen op deze reis. Dit was het einde van de cursus, maar eigenlijk ook het begin van een nieuw hoofdstuk in jouw leven. 🌱💚</p>\n\n<p><strong>Met liefde,<br>\nDanielle</strong></p>"
+      "lead": "Kennis wordt pas waardevol als ze zichtbaar wordt in je agenda, keuken en boodschappenlijst. Dit is jouw korte uitvoerfase.",
+      "opening": [
+        "Je hebt nu genoeg geleerd om te handelen zonder alles tegelijk te veranderen. De komende veertien dagen test je een persoonlijke set van maximaal zes gewoonten. Niet om perfect te scoren, maar om te ontdekken wat in jouw leven blijft werken.",
+        "Kies gedrag dat herhaalbaar en observeerbaar is. ‘Minder toxisch leven’ kun je niet afvinken; ‘eten voor opwarmen op een bord leggen’ wel."
+      ],
+      "sections": [
+        {
+          "title": "Kies zes gewoonten over vier domeinen",
+          "paragraphs": [
+            "Neem twee keukenacties, één lucht- of stofactie, één verzorgings- of schoonmaakactie, één voedings- of herstelactie en één onderzoeksactie. Daarmee voorkom je dat je alleen producten vervangt en de grotere basis vergeet.",
+            "Iedere gewoonte krijgt een anker, minimale versie en herstelregel. Voorbeeld: na het avondeten loop ik tien minuten; op een drukke dag vijf; gemist betekent morgen hervatten, niet compenseren."
+          ],
+          "bullets": [
+            "Keuken: overpakken, materiaalcheck, koud kraanwater gebruiken.",
+            "Lucht en stof: afzuiging vooraf, vochtig afnemen, handen vóór eten.",
+            "Verzorging: één spray minder, product opmaken, eenvoudige routine.",
+            "Herstel: ankermaaltijd, wandeling, vaste slaapafbouw.",
+            "Onderzoek: waterinformatie of één fabrikantvraag controleren."
+          ]
+        },
+        {
+          "title": "Meet gedrag, niet ‘toxines’",
+          "paragraphs": [
+            "Zet veertien vakjes achter iedere gewoonte en vink alleen uitvoering af. Geef daarnaast dagelijks een score voor moeite van één tot vijf. Een gewoonte die bijna altijd lukt met moeite één of twee is een goede kandidaat voor je standaard.",
+            "Meet geen vage lichamelijke klachten als bewijs van ontgifting. Je mag energie, slaap of huid natuurlijk volgen, maar trek na twee weken geen grote oorzaak-gevolgconclusies."
+          ],
+          "note": "Het succescriterium is niet 100 procent. Tien van veertien dagen kan al laten zien dat een gewoonte stevig genoeg is."
+        },
+        {
+          "title": "Plan terugval vóórdat die gebeurt",
+          "paragraphs": [
+            "Vakantie, ziekte en deadlines verstoren routines. Schrijf daarom vooraf je minimale reset: drie gedragingen die zelfs in een chaotische week overeind blijven. Bijvoorbeeld niet in plastic opwarmen, ventileren tijdens koken en handen wassen voor eten.",
+            "Na een gemiste dag begin je bij de volgende gelegenheid. Geen inhaalprogramma, geen straf en geen extra supplement."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Vul je 14-daagse kaart",
+        "time": "25 minuten",
+        "intro": "Kies maximaal zes gedragingen; minder mag als je week al vol is.",
+        "steps": [
+          "Schrijf elk gedrag zo concreet dat een ander het kan afvinken.",
+          "Voeg anker, minimale versie en herstelregel toe.",
+          "Maak veertien vakjes en plan twee evaluatiemomenten.",
+          "Omcirkel je drie gedragingen voor een chaotische week."
+        ],
+        "reflection": "Welke gewoonte zou je over zes maanden nog steeds willen uitvoeren?"
+      },
+      "remember": [
+        "Kies maximaal zes concrete gedragingen.",
+        "Meet uitvoering en moeite, niet een onmeetbare toxinelast.",
+        "Een herstelregel voorkomt dat één gemiste dag een mislukking wordt."
+      ]
+    },
+    {
+      "id": "cr2-les-23-thuis-haalbaar",
+      "index": 23,
+      "title": "Maak het thuis haalbaar",
+      "type": "Plan",
+      "duration_min": 9,
+      "draft": false,
+      "lead": "Een huishouden verandert niet door gelijk krijgen, maar door keuzes makkelijker, betaalbaar en gezamenlijk te maken.",
+      "opening": [
+        "Misschien woon je met iemand die deze cursus niet volgt, kinderen die hun eigen voorkeuren hebben of huisgenoten die verandering overdreven vinden. Dan is méér informatie geven zelden de eerste oplossing. Begin met een concreet probleem en een simpele routine die niemand veel kost.",
+        "Je hoeft niet namens iedereen angst te dragen. Je kunt wel de omgeving zo inrichten dat een goede keuze weinig uitleg nodig heeft."
+      ],
+      "sections": [
+        {
+          "title": "Praat vanuit functie en rust",
+          "paragraphs": [
+            "Zeg niet: ‘alles in deze kast is giftig’. Zeg: ‘ik wil eten voortaan op dit bord opwarmen, omdat hitte en beschadigd plastic een combinatie is die we makkelijk kunnen vermijden’. Een specifiek verzoek is minder bedreigend en beter bespreekbaar.",
+            "Erken bezwaren over geld, tijd en gemak. Als jouw plan extra werk bij een ander neerlegt, is weerstand logisch. Ontwerp de routine opnieuw zodat jij verantwoordelijkheid neemt of de verandering werkelijk eenvoudiger wordt."
+          ],
+          "bullets": [
+            "Vraag één verandering tegelijk.",
+            "Leg het geschikte materiaal op de makkelijkste plek.",
+            "Gebruik neutrale taal en vermijd rampscenario’s.",
+            "Vier wat al lukt zonder de rest van het huis te controleren."
+          ]
+        },
+        {
+          "title": "Maak een gezinsstandaard met uitzonderingen",
+          "paragraphs": [
+            "Een standaard is wat je meestal doet; een uitzondering is geen mislukking. Thuis warm je bijvoorbeeld op in glas of keramiek, onderweg gebruik je wat beschikbaar en veilig is. Daardoor blijft sociaal leven mogelijk.",
+            "Bij kinderen ligt extra nadruk op handen wassen voor eten, veilig speelgoed, ventilatie, stofbeperking en producten gebruiken volgens leeftijdsinstructies. Maak geen medische of voedingsbeperkingen zonder deskundig advies."
+          ],
+          "note": "Een ontspannen standaard die het gezin meestal volgt, verlaagt waarschijnlijk meer blootstelling dan een perfecte regel waar iedereen tegen vecht."
+        },
+        {
+          "title": "Bouw een klein vervangbudget",
+          "paragraphs": [
+            "Plan vervanging per kwartaal en begin bij dagelijks heet voedselcontact of duidelijke schade. Zoek tweedehands alleen wanneer materiaal en staat betrouwbaar te beoordelen zijn. Duur is niet automatisch veiliger.",
+            "Noteer vóór aankoop maat, functie, onderhoud en bewijs voor belangrijke claims. Een aankoop die exact past voorkomt dat je later opnieuw koopt."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Het huishoudgesprek van vijftien minuten",
+        "time": "15 minuten",
+        "intro": "Kies een rustig moment en bespreek maximaal drie voorstellen.",
+        "steps": [
+          "Begin met wat je wilt bereiken, niet met wat anderen fout doen.",
+          "Vraag welk bezwaar of gemakspunt voor de ander telt.",
+          "Kies samen één keuken-, één lucht- en één aankoopstandaard.",
+          "Spreek af wanneer jullie evalueren en welke uitzonderingen prima zijn."
+        ],
+        "reflection": "Welke formulering nodigt uit tot samenwerking in plaats van verdediging?"
+      },
+      "remember": [
+        "Specifieke verzoeken werken beter dan algemene angsttaal.",
+        "Een standaard mag uitzonderingen hebben.",
+        "Inrichting en gedeeld gemak zijn sterker dan controle."
+      ]
+    },
+    {
+      "id": "cr2-les-24-nieuwe-standaard",
+      "index": 24,
+      "title": "Jouw nieuwe standaard",
+      "type": "Afronding",
+      "duration_min": 10,
+      "draft": false,
+      "lead": "Je eindigt niet met een schoner imago, maar met een scherper kompas: weten wat telt, wat onzeker is en welke keuzes bij jou blijven.",
+      "opening": [
+        "Vier weken geleden voelde het onderwerp misschien groot en ongrijpbaar. Nu kun je onderscheid maken tussen aanwezigheid en risico, tussen bronaanpak en marketing, tussen nuttige voorzorg en dure schijnzekerheid. Dat is echte winst: je bent minder makkelijk bang te maken én minder makkelijk iets wijs te maken.",
+        "Je huis hoeft niet toxinevrij te zijn — die belofte kan niemand eerlijk doen. Je kunt wel een omgeving bouwen met minder onnodige blootstelling en meer rust."
+      ],
+      "sections": [
+        {
+          "title": "Maak je persoonlijke standaard definitief",
+          "paragraphs": [
+            "Kies vijf tot acht regels die je het komende halfjaar wilt behouden. Schrijf ze positief en concreet. Bijvoorbeeld: ‘Ik warm eten op in glas of keramiek’, ‘Ik zet ventilatie aan vóór het koken’ en ‘Ik wacht 72 uur met detoxaankopen’.",
+            "Voeg per regel een reden toe. Niet ‘omdat plastic giftig is’, maar ‘omdat ik dagelijks onnodige hitte en slijtage wil vermijden’. Een precieze reden maakt je flexibeler wanneer omstandigheden veranderen."
+          ],
+          "bullets": [
+            "Kies gedrag dat je zelf kunt uitvoeren.",
+            "Houd kosten, tijd en gezondheid in balans.",
+            "Werk met logische vervangmomenten.",
+            "Herzie een regel wanneer nieuwe betrouwbare informatie daarom vraagt."
+          ]
+        },
+        {
+          "title": "Gebruik de maandelijkse reset van twintig minuten",
+          "paragraphs": [
+            "Plan maandelijks een korte controle: zijn materialen beschadigd, zijn filters of ventilatie onderhouden, is een routine weggezakt en is er nieuwe lokale informatie die echt relevant is? Stop na twintig minuten. Je hoeft geen eindeloze nieuwszoektocht te doen.",
+            "Kies per kwartaal maximaal één verbetering. Zo groeit je huishouden mee met slijtage en budget zonder een grote eenmalige schoonmaakgolf."
+          ],
+          "note": "Onderhoud is het volwassen vervolg op motivatie: klein, gepland en weinig spectaculair."
+        },
+        {
+          "title": "Wat je vanaf nu mag loslaten",
+          "paragraphs": [
+            "Je mag loslaten dat ieder vaag symptoom door ‘toxines’ komt. Je mag loslaten dat duurder altijd veiliger is. Je mag loslaten dat één fout moment je hele reset ongedaan maakt. En je mag mensen volgen of merken kopen zonder hun angsttaal over te nemen.",
+            "Wat blijft is een rustige vraag: welke bron, welke blootstelling, welk bewijs en welke proportionele stap? Met die vier vragen kun je verder, ook wanneer de volgende alarmerende stof morgen in het nieuws verschijnt."
+          ]
+        },
+        {
+          "title": "Jouw slotbelofte",
+          "paragraphs": [
+            "Je hebt geen perfecte controle nodig om zorgzaam met jezelf en je omgeving om te gaan. Iedere keer dat je een herhaalde blootstelling verstandig vermindert, een misleidende claim doorziet of onnodige angst niet doorgeeft, oefen je regie.",
+            "Dat is Clean Reset: niet één schoon moment, maar een blijvend vermogen om warm, kritisch en praktisch te kiezen."
+          ]
+        }
+      ],
+      "assignment": {
+        "title": "Schrijf je Clean Reset-kompas",
+        "time": "25 minuten",
+        "intro": "Maak één pagina die je over zes maanden nog begrijpt.",
+        "steps": [
+          "Schrijf vijf tot acht persoonlijke standaarden met hun reden.",
+          "Noteer drie marketingclaims waar je niet meer op reageert.",
+          "Plan je maandelijkse twintig minuten en één kwartaalverbetering.",
+          "Maak de zin af: ‘Regie betekent voor mij vanaf nu …’"
+        ],
+        "reflection": "Welke verandering in je manier van denken is waardevoller dan een nieuw product?"
+      },
+      "remember": [
+        "Je doel is minder vermijdbare blootstelling, niet een onmogelijk toxinevrij leven.",
+        "Een maandelijkse korte check houdt je standaard levend.",
+        "Bron, blootstelling, bewijs en proportie vormen je blijvende kompas."
+      ],
+      "sources": [
+        { "label": "RIVM — PFAS en voedsel", "url": "https://www.rivm.nl/pfas/voedsel" },
+        { "label": "RIVM — plastics en gezondheid", "url": "https://www.rivm.nl/plastics/gevolgen-gezondheid" },
+        { "label": "EFSA — Bisphenol A", "url": "https://www.efsa.europa.eu/en/topics/topic/bisphenol" },
+        { "label": "Voedingscentrum — bestrijdingsmiddelen", "url": "https://www.voedingscentrum.nl/encyclopedie/bestrijdingsmiddelen.aspx" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Wat verandert\n- vervangt de oude 51 korte lessen door 24 inhoudelijke lessen in 6 modules\n- voegt ruim 10.000 woorden, praktische opdrachten, reflecties en kernsamenvattingen toe\n- behandelt PFAS, microplastics, bisfenolen, ftalaten, parabenen en pesticiden zonder wonderclaims\n- voegt een onderhoudbare structured-content renderer en premium lescomponenten toe\n- start Clean Reset v2 met schone, versiegebonden voortgang\n\n## Gecontroleerd\n- JSON/schema en JavaScript-syntax\n- alle 24 lessen, 6 hoofdstukken en nieuwe voortgang lokaal\n- lesnavigatie, opdrachten, bronlinks en browserconsole\n- desktop- en mobiele cursusweergave\n\n## Openstaand\nDe twee gevraagde nieuwe cursusfoto's zijn nog niet opgenomen omdat de ingebouwde beeldgenerator tweemaal technisch met HTTP 404 faalde; er is bewust geen betaalde API-omweg gebruikt.